### PR TITLE
Add interactive dataset creation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
 models/
 data/
+datasets/
 venv/

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ python scripts/check_env.py
 
 ## Training
 
-Execute the training script to download the dataset, preprocess it and start training. Models and datasets are cached under `models/` and `data/` in the repository root.
+Execute the training script to download the dataset, preprocess it and start training. Models and datasets are cached under `models/` and `datasets/` in the repository root.
 
 ```bash
 python scripts/train_interactive.py
@@ -54,7 +54,7 @@ For convenience, `train_interactive.py` and `infer_interactive.py` provide an in
 The `Whisper` directory contains tools to convert long audio recordings into a Hugging Face style dataset. Use `prepare_dataset.py` to create a local dataset from an audio file:
 
 ```bash
-python scripts/prepare_dataset.py path/to/audio.mp3 data/my_dataset
+python scripts/prepare_dataset.py path/to/audio.mp3 datasets/my_dataset
 ```
 
-The script runs WhisperX to transcribe and segment the audio, then saves a dataset under `data/my_dataset`. You can load this dataset in the interactive training script by choosing the *Local Whisper dataset* option and providing the saved folder path.
+The script runs WhisperX to transcribe and segment the audio, then saves a dataset under `datasets/my_dataset`. You can load this dataset in the interactive training script by choosing the *Local Whisper dataset* option and providing the saved folder path.

--- a/scripts/prepare_dataset_interactive.py
+++ b/scripts/prepare_dataset_interactive.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+"""Interactive wrapper for ``prepare_dataset.py`` using WhisperX.
+
+This script lists audio files found in ``source_audio`` and lets the user
+select one to transcribe. The resulting dataset is saved under ``datasets``
+with a folder name matching the audio file stem.
+"""
+import os
+from pathlib import Path
+
+# Import the helper from the existing script
+from prepare_dataset import prepare_dataset
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    audio_dir = repo_root / "source_audio"
+    dataset_root = repo_root / "datasets"
+    dataset_root.mkdir(parents=True, exist_ok=True)
+
+    audio_files = [f for f in os.listdir(audio_dir)
+                   if f.lower().endswith((".mp3", ".wav"))]
+    if not audio_files:
+        print("No se encontraron archivos de audio en 'source_audio'.")
+        return
+
+    print("Seleccione el archivo de audio a procesar:")
+    for idx, name in enumerate(audio_files, 1):
+        print(f"{idx}. {name}")
+
+    choice = input("Elecci\u00f3n [1]: ").strip() or "1"
+    if not choice.isdigit() or not (1 <= int(choice) <= len(audio_files)):
+        selected = audio_files[0]
+    else:
+        selected = audio_files[int(choice) - 1]
+
+    audio_path = audio_dir / selected
+    output_dir = dataset_root / Path(selected).stem
+    prepare_dataset(str(audio_path), str(output_dir))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -32,7 +32,7 @@ model = FastLanguageModel.get_peft_model(
 )
 
 # dataset loading
-DATA_DIR = os.path.join(os.path.dirname(__file__), '..', 'data')
+DATA_DIR = os.path.join(os.path.dirname(__file__), '..', 'datasets')
 dataset = load_dataset("MrDragonFox/Elise", split="train", cache_dir=DATA_DIR)
 
 # Tokenization functions

--- a/scripts/train_interactive.py
+++ b/scripts/train_interactive.py
@@ -39,7 +39,7 @@ model = FastLanguageModel.get_peft_model(
 )
 
 # dataset loading with interactive prompt
-DATA_DIR = os.path.join(os.path.dirname(__file__), '..', 'data')
+DATA_DIR = os.path.join(os.path.dirname(__file__), '..', 'datasets')
 default_dataset = "MrDragonFox/Elise"
 print("Select dataset source:")
 print("1. Hugging Face link")


### PR DESCRIPTION
## Summary
- add a script to pick an audio file from `source_audio` and build a dataset via WhisperX
- store datasets under `datasets/`
- update training scripts to look for datasets in the new folder
- update documentation and gitignore

## Testing
- `python -m py_compile scripts/train_interactive.py scripts/train.py scripts/prepare_dataset_interactive.py`


------
https://chatgpt.com/codex/tasks/task_e_68431992cf988327b53f1dc0561ce45d