### PR TITLE
Fix dataset script import

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -31,3 +31,8 @@ pip install torch==${TORCH_VER} torchvision==0.21.0 torchaudio==${TORCH_VER} --i
 
 echo "All dependencies installed with torch==${TORCH_VER}"
 echo "Activate the environment with: source $VENV_DIR/bin/activate"
+
+# Additional CUDA dependencies
+if command -v apt >/dev/null; then
+  sudo apt install libcudnn8 libcudnn8-dev
+fi

--- a/scripts/prepare_dataset.py
+++ b/scripts/prepare_dataset.py
@@ -7,8 +7,14 @@ converted into a ``datasets`` Dataset and saved to disk so that it can be loaded
 with ``load_from_disk``.
 """
 import os
+import sys
 from pathlib import Path
 from datasets import Audio, Dataset
+
+# Make sure the repository root is on the Python path so ``tools`` can be found
+repo_root = Path(__file__).resolve().parent.parent
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))
 
 # Import helper functions from the Whisper package
 from tools.Whisper import run as whisper_run


### PR DESCRIPTION
## Summary
- fix dataset scripts to locate the `tools` package by inserting the repo root into `sys.path`
- update installation script with CUDA dependencies

## Testing
- `python scripts/prepare_dataset_interactive.py` *(fails: ModuleNotFoundError: No module named 'datasets')*

------
https://chatgpt.com/codex/tasks/task_e_68431e9a0b808327ad9a1eae4687512d