### PR TITLE
Fix dataset script import

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ The `Whisper` directory contains tools to convert long audio recordings into a H
 python scripts/prepare_dataset.py path/to/audio.mp3 datasets/my_dataset
 ```
 
-The script runs WhisperX to transcribe and segment the audio, then saves a dataset under `datasets/my_dataset`. You can load this dataset in the interactive training script by choosing the *Local Whisper dataset* option and providing the saved folder path.
+The script runs WhisperX to transcribe and segment the audio, then saves a dataset under `datasets/my_dataset`. A copy of the dataset is also written to `datasets/my_dataset/dataset.parquet` for easy sharing. You can load this dataset in the interactive training script by choosing the *Local Whisper dataset* option and providing the saved folder path.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -31,3 +31,8 @@ pip install torch==${TORCH_VER} torchvision==0.21.0 torchaudio==${TORCH_VER} --i
 
 echo "All dependencies installed with torch==${TORCH_VER}"
 echo "Activate the environment with: source $VENV_DIR/bin/activate"
+
+# Additional CUDA dependencies
+if command -v apt >/dev/null; then
+  sudo apt install libcudnn8 libcudnn8-dev
+fi

--- a/scripts/prepare_dataset.py
+++ b/scripts/prepare_dataset.py
@@ -3,12 +3,18 @@
 
 This script uses the functions from ``tools/Whisper/run.py`` to transcribe an audio
 file and segment it. The resulting ``.wav`` and ``.txt`` pairs are then
-converted into a ``datasets`` Dataset and saved to disk so that it can be loaded
-with ``load_from_disk``.
+converted into a ``datasets`` Dataset and saved to disk (and as a ``.parquet``
+file) so that it can be loaded with ``load_from_disk`` or other tools.
 """
 import os
+import sys
 from pathlib import Path
 from datasets import Audio, Dataset
+
+# Make sure the repository root is on the Python path so ``tools`` can be found
+repo_root = Path(__file__).resolve().parent.parent
+if str(repo_root) not in sys.path:
+    sys.path.insert(0, str(repo_root))
 
 # Import helper functions from the Whisper package
 from tools.Whisper import run as whisper_run
@@ -32,7 +38,11 @@ def prepare_dataset(audio_path: str, output_dir: str) -> None:
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     dataset.save_to_disk(output_dir)
+    # Also store the dataset in Parquet format for easy sharing
+    parquet_path = output_dir / "dataset.parquet"
+    dataset.to_parquet(parquet_path)
     print(f"Dataset saved under {output_dir.resolve()}")
+    print(f"Parquet file written to {parquet_path.resolve()}")
 
 
 def main():

--- a/scripts/prepare_dataset_interactive.py
+++ b/scripts/prepare_dataset_interactive.py
@@ -37,6 +37,8 @@ def main() -> None:
     audio_path = audio_dir / selected
     output_dir = dataset_root / Path(selected).stem
     prepare_dataset(str(audio_path), str(output_dir))
+    print(f"Dataset directory: {output_dir.resolve()}")
+    print(f"Parquet file: {(output_dir / 'dataset.parquet').resolve()}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix dataset scripts to locate the `tools` package by inserting the repo root into `sys.path`
- update installation script with CUDA dependencies
- save dataset as a Parquet file alongside HF dataset directory

## Testing
- `python scripts/prepare_dataset_interactive.py` *(fails: ModuleNotFoundError: No module named 'transformers')*


------
https://chatgpt.com/codex/tasks/task_e_68431e9a0b808327ad9a1eae4687512d