### PR TITLE
Add main CLI menu

### DIFF
--- a/scripts/orpheus_cli.py
+++ b/scripts/orpheus_cli.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+"""Simple interactive CLI to manage OrpheusX workflows."""
+import os
+import subprocess
+from pathlib import Path
+
+# Resolve repository root based on script location
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+
+def run_script(command, shell=False):
+    """Run a command as subprocess and stream its output."""
+    try:
+        subprocess.run(command, check=True, cwd=str(SCRIPTS_DIR), shell=shell)
+    except subprocess.CalledProcessError as exc:
+        print(f"Command failed: {exc}")
+
+
+def install():
+    run_script(["bash", "install.sh"])
+
+
+def create_dataset():
+    run_script(["python", "prepare_dataset_interactive.py"])
+
+
+def train():
+    run_script(["python", "train_interactive.py"])
+
+
+def infer():
+    run_script(["python", "infer_interactive.py"])
+
+
+MENU_OPTIONS = {
+    "1": ("Instalacion", install),
+    "2": ("Crear dataset", create_dataset),
+    "3": ("Entrenamiento", train),
+    "4": ("Inferencia", infer),
+    "5": ("Salir", None),
+}
+
+
+def main() -> None:
+    while True:
+        print("\nOrpheusX CLI")
+        for key, (label, _) in MENU_OPTIONS.items():
+            print(f"{key}. {label}")
+        choice = input("Elige una opcion [5]: ").strip() or "5"
+        if choice == "5":
+            print("Bye!")
+            break
+        action = MENU_OPTIONS.get(choice)
+        if not action:
+            print("Opcion invalida")
+            continue
+        _, func = action
+        func()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `orpheus_cli.py` to offer a unified interactive menu

## Testing
- `python scripts/orpheus_cli.py <<'EOF'
5
EOF`
- `python scripts/check_env.py` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68434e4ca6988327b5732d7554c5a7d5