### PR TITLE
Fix LoRA directory handling in Gradio UI

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -17,7 +17,8 @@ from scripts.prepare_dataset import prepare_dataset
 
 REPO_ROOT = Path(__file__).resolve().parent
 DATASETS_DIR = REPO_ROOT / "datasets"
-LORA_DIR = REPO_ROOT / "lora_models"
+# Match the CLI scripts which store LoRAs under ``scripts/lora_models``
+LORA_DIR = REPO_ROOT / "scripts" / "lora_models"
 PROMPT_LIST_DIR = REPO_ROOT / "prompt_list"
 MAX_PROMPTS = 5
 


### PR DESCRIPTION
## Summary
- point the Gradio interface to `scripts/lora_models` so LoRAs are loaded and saved consistently with the CLI tools

## Testing
- `python -m py_compile gradio_app.py`
- `python -m py_compile scripts/train_interactive.py scripts/infer_interactive.py`


------
https://chatgpt.com/codex/tasks/task_e_68443798041c8327b39182f6b14fa7ac