### PR TITLE
Fix LoRA directory handling in Gradio UI

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -17,7 +17,8 @@ from scripts.prepare_dataset import prepare_dataset
 
 REPO_ROOT = Path(__file__).resolve().parent
 DATASETS_DIR = REPO_ROOT / "datasets"
-LORA_DIR = REPO_ROOT / "lora_models"
+# Match the CLI scripts which store LoRAs under ``scripts/lora_models``
+LORA_DIR = REPO_ROOT / "scripts" / "lora_models"
 PROMPT_LIST_DIR = REPO_ROOT / "prompt_list"
 MAX_PROMPTS = 5
 
@@ -360,8 +361,19 @@ dataset_choices = list_datasets()
 lora_choices = list_loras()
 prompt_files = list_prompt_files()
 
+
+def refresh_lists() -> tuple[gr.Update, gr.Update, gr.Update]:
+    """Reload datasets, LoRAs and prompt lists from disk."""
+    return (
+        gr.update(choices=list_datasets()),
+        gr.update(choices=["<base>"] + list_loras()),
+        gr.update(choices=list_prompt_files()),
+    )
+
 with gr.Blocks() as demo:
     gr.Markdown("# OrpheusX Gradio Interface")
+
+    refresh_btn = gr.Button("Refresh directories")
 
     with gr.Tab("Prepare Dataset"):
         audio_input = gr.Audio(type="filepath")
@@ -419,6 +431,8 @@ with gr.Blocks() as demo:
             [mode, num_prompts] + prompt_boxes + [prompt_list_dd, lora_used],
             gallery,
         )
+
+    refresh_btn.click(refresh_lists, None, [local_ds, lora_used, prompt_list_dd])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- point the Gradio interface to `scripts/lora_models` so LoRAs are loaded and saved consistently with the CLI tools
- add a refresh button so datasets, LoRAs, and prompt lists can be reloaded without restarting Gradio

## Testing
- `python -m py_compile gradio_app.py scripts/train_interactive.py scripts/infer_interactive.py`


------
https://chatgpt.com/codex/tasks/task_e_68443798041c8327b39182f6b14fa7ac