### PR TITLE
Fix Spanish text in gradio app

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -437,10 +437,10 @@ with gr.Blocks() as demo:
 
 
 if __name__ == "__main__":
-    port_input = input("¿En qué puerto desea abrir Gradio? (default 7860): ")
+    port_input = input("Which port should Gradio use? (default 7860): ")
     try:
         port = int(port_input) if port_input.strip() else 7860
     except ValueError:
-        print("Valor inválido, usando el puerto 7860")
+        print("Invalid value, using port 7860")
         port = 7860
     demo.launch(server_port=port)


### PR DESCRIPTION
## Summary
- translate Spanish prompts in `gradio_app.py`

## Testing
- `python -m py_compile gradio_app.py`


------
https://chatgpt.com/codex/tasks/task_e_6844b063f20c8327a0c2c3e12cf3521d