### PR TITLE
Add optional long text segmentation

### DIFF
--- a/scripts/infer.py
+++ b/scripts/infer.py
@@ -23,10 +23,78 @@ def load_model(model_name, lora_path=None):
     FastLanguageModel.for_inference(model)
     return model, tokenizer
 
+
+def split_by_tokens(input_ids: torch.Tensor, chunk_size: int = 30) -> list[torch.Tensor]:
+    """Split a tensor of token ids into ``chunk_size`` chunks."""
+    return [input_ids[i : i + chunk_size] for i in range(0, input_ids.size(0), chunk_size)]
+
+
+def generate_audio_segment(tokens: torch.Tensor, model, snac_model) -> torch.Tensor:
+    """Generate audio for given token IDs and return as 1D tensor."""
+    start_token = torch.tensor([[128259]], dtype=torch.int64)
+    end_tokens = torch.tensor([[128009, 128260]], dtype=torch.int64)
+    modified_input = torch.cat([start_token, tokens.unsqueeze(0), end_tokens], dim=1)
+    attention_mask = torch.ones_like(modified_input)
+    input_ids_cuda = modified_input.to("cuda")
+    attn_cuda = attention_mask.to("cuda")
+    generated = model.generate(
+        input_ids=input_ids_cuda,
+        attention_mask=attn_cuda,
+        max_new_tokens=1200,
+        do_sample=True,
+        temperature=0.6,
+        top_p=0.95,
+        repetition_penalty=1.1,
+        num_return_sequences=1,
+        eos_token_id=128258,
+        use_cache=True,
+    )
+    token_to_find = 128257
+    token_to_remove = 128258
+    token_indices = (generated == token_to_find).nonzero(as_tuple=True)
+    if len(token_indices[1]) > 0:
+        last_occurrence_idx = token_indices[1][-1].item()
+        cropped_tensor = generated[:, last_occurrence_idx + 1 :]
+    else:
+        cropped_tensor = generated
+    processed_rows = []
+    for row in cropped_tensor:
+        masked_row = row[row != token_to_remove]
+        processed_rows.append(masked_row)
+    code_lists = []
+    for row in processed_rows:
+        row_length = row.size(0)
+        new_length = (row_length // 7) * 7
+        trimmed_row = row[:new_length]
+        trimmed_row = [t - 128266 for t in trimmed_row]
+        code_lists.append(trimmed_row)
+
+    def redistribute_codes(code_list):
+        layer_1, layer_2, layer_3 = [], [], []
+        for i in range((len(code_list) + 1) // 7):
+            layer_1.append(code_list[7 * i])
+            layer_2.append(code_list[7 * i + 1] - 4096)
+            layer_3.append(code_list[7 * i + 2] - (2 * 4096))
+            layer_3.append(code_list[7 * i + 3] - (3 * 4096))
+            layer_2.append(code_list[7 * i + 4] - (4 * 4096))
+            layer_3.append(code_list[7 * i + 5] - (5 * 4096))
+            layer_3.append(code_list[7 * i + 6] - (6 * 4096))
+        codes = [
+            torch.tensor(layer_1).unsqueeze(0),
+            torch.tensor(layer_2).unsqueeze(0),
+            torch.tensor(layer_3).unsqueeze(0),
+        ]
+        audio_hat = snac_model.decode(codes)
+        return audio_hat
+
+    samples = [redistribute_codes(c) for c in code_lists]
+    return samples[0].squeeze(0)
+
 def main():
     parser = argparse.ArgumentParser(description='Interactive Orpheus TTS inference')
     parser.add_argument('--model', default='unsloth/orpheus-3b-0.1-ft', help='Model name or path')
     parser.add_argument('--lora', default='lora_model', help='Path to trained LoRA adapters')
+    parser.add_argument('--segment', action='store_true', help='Segment prompts every 30 tokens')
     args = parser.parse_args()
     model, tokenizer = load_model(args.model, args.lora)
 
@@ -87,68 +155,13 @@ def main():
             text = input('Enter text (or blank to quit): ').strip()
         if not text:
             break
-        input_ids = tokenizer(text, return_tensors='pt').input_ids
-        start_token = torch.tensor([[128259]], dtype=torch.int64)
-        end_tokens = torch.tensor([[128009, 128260]], dtype=torch.int64)
-        modified_input = torch.cat([start_token, input_ids, end_tokens], dim=1)
-        padding = 0
-        attention_mask = torch.ones_like(modified_input)
-        input_ids_cuda = modified_input.to('cuda')
-        attn_cuda = attention_mask.to('cuda')
-        generated = model.generate(
-            input_ids=input_ids_cuda,
-            attention_mask=attn_cuda,
-            max_new_tokens=1200,
-            do_sample=True,
-            temperature=0.6,
-            top_p=0.95,
-            repetition_penalty=1.1,
-            num_return_sequences=1,
-            eos_token_id=128258,
-            use_cache=True,
-        )
-        token_to_find = 128257
-        token_to_remove = 128258
-        token_indices = (generated == token_to_find).nonzero(as_tuple=True)
-        if len(token_indices[1]) > 0:
-            last_occurrence_idx = token_indices[1][-1].item()
-            cropped_tensor = generated[:, last_occurrence_idx+1:]
-        else:
-            cropped_tensor = generated
-        processed_rows = []
-        for row in cropped_tensor:
-            masked_row = row[row != token_to_remove]
-            processed_rows.append(masked_row)
-        code_lists = []
-        for row in processed_rows:
-            row_length = row.size(0)
-            new_length = (row_length // 7) * 7
-            trimmed_row = row[:new_length]
-            trimmed_row = [t - 128266 for t in trimmed_row]
-            code_lists.append(trimmed_row)
-        def redistribute_codes(code_list):
-            layer_1 = []
-            layer_2 = []
-            layer_3 = []
-            for i in range((len(code_list)+1)//7):
-                layer_1.append(code_list[7*i])
-                layer_2.append(code_list[7*i+1]-4096)
-                layer_3.append(code_list[7*i+2]-(2*4096))
-                layer_3.append(code_list[7*i+3]-(3*4096))
-                layer_2.append(code_list[7*i+4]-(4*4096))
-                layer_3.append(code_list[7*i+5]-(5*4096))
-                layer_3.append(code_list[7*i+6]-(6*4096))
-            codes = [torch.tensor(layer_1).unsqueeze(0),
-                     torch.tensor(layer_2).unsqueeze(0),
-                     torch.tensor(layer_3).unsqueeze(0)]
-            audio_hat = snac_model.decode(codes)
-            return audio_hat
-        samples = [redistribute_codes(c) for c in code_lists]
-        for sample in samples:
-            path = 'output.wav'
-            audio_2d = sample.squeeze(0)
-            torchaudio.save(path, audio_2d.detach().cpu(), 24000)
-            print(f'Audio written to {path}')
+        full_ids = tokenizer(text, return_tensors='pt').input_ids.squeeze(0)
+        segments = split_by_tokens(full_ids) if args.segment else [full_ids]
+        audio_parts = [generate_audio_segment(ids, model, snac_model) for ids in segments]
+        final_audio = torch.cat(audio_parts, dim=-1)
+        path = 'output.wav'
+        torchaudio.save(path, final_audio.detach().cpu(), 24000)
+        print(f'Audio written to {path}')
 
 if __name__ == '__main__':
     main()

--- a/scripts/infer_interactive.py
+++ b/scripts/infer_interactive.py
@@ -8,6 +8,7 @@ files are never overwritten.
 """
 import os
 import json
+import argparse
 import torch
 import torchaudio
 from unsloth import FastLanguageModel
@@ -42,7 +43,82 @@ def get_output_path(lora_name: str, ext: str = ".wav") -> str:
         idx += 1
 
 
+def split_by_tokens(input_ids: torch.Tensor, chunk_size: int = 30) -> list[torch.Tensor]:
+    """Split a tensor of token ids into chunks of ``chunk_size``."""
+    return [input_ids[i : i + chunk_size] for i in range(0, input_ids.size(0), chunk_size)]
+
+
+def generate_audio_segment(tokens: torch.Tensor, model, snac_model) -> torch.Tensor:
+    """Generate audio for a single token chunk and return as 1D tensor."""
+    start_token = torch.tensor([[128259]], dtype=torch.int64)
+    end_tokens = torch.tensor([[128009, 128260]], dtype=torch.int64)
+    modified_input = torch.cat([start_token, tokens.unsqueeze(0), end_tokens], dim=1)
+    attention_mask = torch.ones_like(modified_input)
+    input_ids_cuda = modified_input.to("cuda")
+    attn_cuda = attention_mask.to("cuda")
+    generated = model.generate(
+        input_ids=input_ids_cuda,
+        attention_mask=attn_cuda,
+        max_new_tokens=1200,
+        do_sample=True,
+        temperature=0.6,
+        top_p=0.95,
+        repetition_penalty=1.1,
+        num_return_sequences=1,
+        eos_token_id=128258,
+        use_cache=True,
+    )
+    token_to_find = 128257
+    token_to_remove = 128258
+    token_indices = (generated == token_to_find).nonzero(as_tuple=True)
+    if len(token_indices[1]) > 0:
+        last_occurrence_idx = token_indices[1][-1].item()
+        cropped_tensor = generated[:, last_occurrence_idx + 1 :]
+    else:
+        cropped_tensor = generated
+    processed_rows = []
+    for row in cropped_tensor:
+        masked_row = row[row != token_to_remove]
+        processed_rows.append(masked_row)
+    code_lists = []
+    for row in processed_rows:
+        row_length = row.size(0)
+        new_length = (row_length // 7) * 7
+        trimmed_row = row[:new_length]
+        trimmed_row = [t - 128266 for t in trimmed_row]
+        code_lists.append(trimmed_row)
+
+    def redistribute_codes(code_list):
+        layer_1, layer_2, layer_3 = [], [], []
+        for i in range((len(code_list) + 1) // 7):
+            layer_1.append(code_list[7 * i])
+            layer_2.append(code_list[7 * i + 1] - 4096)
+            layer_3.append(code_list[7 * i + 2] - (2 * 4096))
+            layer_3.append(code_list[7 * i + 3] - (3 * 4096))
+            layer_2.append(code_list[7 * i + 4] - (4 * 4096))
+            layer_3.append(code_list[7 * i + 5] - (5 * 4096))
+            layer_3.append(code_list[7 * i + 6] - (6 * 4096))
+        codes = [
+            torch.tensor(layer_1).unsqueeze(0),
+            torch.tensor(layer_2).unsqueeze(0),
+            torch.tensor(layer_3).unsqueeze(0),
+        ]
+        audio_hat = snac_model.decode(codes)
+        return audio_hat
+
+    samples = [redistribute_codes(c) for c in code_lists]
+    return samples[0].squeeze(0)
+
+
 def main():
+    parser = argparse.ArgumentParser(description="Interactive inference")
+    parser.add_argument(
+        "--segment",
+        action="store_true",
+        help="Segment prompts every 30 tokens",
+    )
+    args = parser.parse_args()
+
     model_name = "unsloth/orpheus-3b-0.1-ft"
     lora_root = "lora_models"
     lora_dirs = []
@@ -123,73 +199,28 @@ def main():
             p = input(f"Prompt {i+1}: ").strip()
             prompts.append(p)
 
+    if args.segment:
+        segment_choice = True
+    else:
+        segment_choice = (
+            input("Segment prompts every 30 tokens? (y/N): ").strip().lower()
+            == "y"
+        )
+
     for lora_choice in selected_loras:
         lora_path = os.path.join(lora_root, lora_choice, "lora_model") if lora_choice else None
         model, tokenizer = load_model(model_name, lora_path)
 
         for text in prompts:
-            input_ids = tokenizer(text, return_tensors='pt').input_ids
-            start_token = torch.tensor([[128259]], dtype=torch.int64)
-            end_tokens = torch.tensor([[128009, 128260]], dtype=torch.int64)
-            modified_input = torch.cat([start_token, input_ids, end_tokens], dim=1)
-            padding = 0
-            attention_mask = torch.ones_like(modified_input)
-            input_ids_cuda = modified_input.to('cuda')
-            attn_cuda = attention_mask.to('cuda')
-            generated = model.generate(
-                input_ids=input_ids_cuda,
-                attention_mask=attn_cuda,
-                max_new_tokens=1200,
-                do_sample=True,
-                temperature=0.6,
-                top_p=0.95,
-                repetition_penalty=1.1,
-                num_return_sequences=1,
-                eos_token_id=128258,
-                use_cache=True,
-            )
-            token_to_find = 128257
-            token_to_remove = 128258
-            token_indices = (generated == token_to_find).nonzero(as_tuple=True)
-            if len(token_indices[1]) > 0:
-                last_occurrence_idx = token_indices[1][-1].item()
-                cropped_tensor = generated[:, last_occurrence_idx+1:]
-            else:
-                cropped_tensor = generated
-            processed_rows = []
-            for row in cropped_tensor:
-                masked_row = row[row != token_to_remove]
-                processed_rows.append(masked_row)
-            code_lists = []
-            for row in processed_rows:
-                row_length = row.size(0)
-                new_length = (row_length // 7) * 7
-                trimmed_row = row[:new_length]
-                trimmed_row = [t - 128266 for t in trimmed_row]
-                code_lists.append(trimmed_row)
-            def redistribute_codes(code_list):
-                layer_1 = []
-                layer_2 = []
-                layer_3 = []
-                for i in range((len(code_list)+1)//7):
-                    layer_1.append(code_list[7*i])
-                    layer_2.append(code_list[7*i+1]-4096)
-                    layer_3.append(code_list[7*i+2]-(2*4096))
-                    layer_3.append(code_list[7*i+3]-(3*4096))
-                    layer_2.append(code_list[7*i+4]-(4*4096))
-                    layer_3.append(code_list[7*i+5]-(5*4096))
-                    layer_3.append(code_list[7*i+6]-(6*4096))
-                codes = [torch.tensor(layer_1).unsqueeze(0),
-                         torch.tensor(layer_2).unsqueeze(0),
-                         torch.tensor(layer_3).unsqueeze(0)]
-                audio_hat = snac_model.decode(codes)
-                return audio_hat
-            samples = [redistribute_codes(c) for c in code_lists]
-            for sample in samples:
-                path = get_output_path(lora_choice or "base_model")
-                audio_2d = sample.squeeze(0)
-                torchaudio.save(path, audio_2d.detach().cpu(), 24000)
-                print(f'Audio written to {path}')
+            full_ids = tokenizer(text, return_tensors="pt").input_ids.squeeze(0)
+            segments = split_by_tokens(full_ids) if segment_choice else [full_ids]
+            audio_parts = [
+                generate_audio_segment(ids, model, snac_model) for ids in segments
+            ]
+            final_audio = torch.cat(audio_parts, dim=-1)
+            path = get_output_path(lora_choice or "base_model")
+            torchaudio.save(path, final_audio.detach().cpu(), 24000)
+            print(f"Audio written to {path}")
 
 if __name__ == '__main__':
     main()

--- a/scripts/orpheus_cli.py
+++ b/scripts/orpheus_cli.py
@@ -45,8 +45,12 @@ def train():
 
 def infer():
     multi = input("Run inference on multiple models? (y/N): ").strip().lower() == "y"
+    segment = input("Segment prompts every 30 tokens? (y/N): ").strip().lower() == "y"
+    cmd = ["python", "infer_interactive.py"]
+    if segment:
+        cmd.append("--segment")
     while True:
-        run_script(["python", "infer_interactive.py"])
+        run_script(cmd)
         if not multi:
             break
         again = input("Run inference with another model? (y/N): ").strip().lower()


### PR DESCRIPTION
## Summary
- allow splitting prompts every 30 tokens during inference
- implement the new option in `infer.py`, `infer_interactive.py`, and the Gradio UI
- add segmentation flag handling in `orpheus_cli.py`
- show audio players in Gradio instead of image thumbnails

## Testing
- `python -m py_compile scripts/infer_interactive.py scripts/infer.py gradio_app.py scripts/orpheus_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_684562c1dad0832792954a71c3c7fc96