### PR TITLE
Improve audio concat with crossfade

### DIFF
--- a/audio_utils.py
+++ b/audio_utils.py
@@ -1,0 +1,34 @@
+import torch
+
+def concat_with_fade(chunks, sample_rate=24000, fade_ms=20):
+    """Concatenate 1D tensors with a short crossfade.
+
+    Parameters
+    ----------
+    chunks : list[torch.Tensor]
+        List of 1D audio tensors to join.
+    sample_rate : int, optional
+        Sample rate of the audio, by default 24000.
+    fade_ms : int, optional
+        Duration of the crossfade in milliseconds, by default 20.
+    Returns
+    -------
+    torch.Tensor
+        The concatenated audio tensor.
+    """
+    if not chunks:
+        return torch.tensor([], dtype=torch.float32)
+    if len(chunks) == 1:
+        return chunks[0]
+    fade_samples = int(sample_rate * fade_ms / 1000)
+    output = chunks[0]
+    for chunk in chunks[1:]:
+        overlap = min(fade_samples, output.size(-1), chunk.size(-1)) if fade_samples > 0 else 0
+        if overlap > 0:
+            fade_out = torch.linspace(1.0, 0.0, overlap, device=output.device)
+            fade_in = torch.linspace(0.0, 1.0, overlap, device=chunk.device)
+            mixed = output[-overlap:] * fade_out + chunk[:overlap] * fade_in
+            output = torch.cat([output[:-overlap], mixed, chunk[overlap:]], dim=-1)
+        else:
+            output = torch.cat([output, chunk], dim=-1)
+    return output

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -12,6 +12,9 @@ from pathlib import Path
 import json
 import gradio as gr
 
+# Helper for audio concatenation with crossfade
+from audio_utils import concat_with_fade
+
 # The prepare_dataset helper can be imported safely
 from scripts.prepare_dataset import prepare_dataset
 
@@ -434,7 +437,7 @@ def generate_audio(
     else:
         segments = [tokenizer(text, return_tensors='pt').input_ids.squeeze(0)]
     audio_parts = [generate_audio_segment(s, model, snac_model) for s in segments]
-    final_audio = torch.cat(audio_parts, dim=-1)
+    final_audio = concat_with_fade(audio_parts)
     lora_name = lora_name or "base_model"
     path = get_output_path(lora_name)
     import torchaudio

--- a/scripts/infer.py
+++ b/scripts/infer.py
@@ -8,6 +8,14 @@ from unsloth import FastLanguageModel
 from snac import SNAC
 from peft import PeftModel
 
+# Root of repository to load helper modules when run from ``scripts`` directory
+import sys
+repo_root = os.path.dirname(os.path.dirname(__file__))
+if repo_root not in sys.path:
+    sys.path.insert(0, repo_root)
+
+from audio_utils import concat_with_fade
+
 CACHE_DIR = os.path.join(os.path.dirname(__file__), '..', 'models')
 
 def load_model(model_name, lora_path=None):
@@ -175,7 +183,7 @@ def main():
         else:
             segments = [tokenizer(text, return_tensors='pt').input_ids.squeeze(0)]
         audio_parts = [generate_audio_segment(ids, model, snac_model) for ids in segments]
-        final_audio = torch.cat(audio_parts, dim=-1)
+        final_audio = concat_with_fade(audio_parts)
         path = 'output.wav'
         torchaudio.save(path, final_audio.detach().cpu(), 24000)
         print(f'Audio written to {path}')

--- a/scripts/infer_interactive.py
+++ b/scripts/infer_interactive.py
@@ -15,6 +15,14 @@ from unsloth import FastLanguageModel
 from snac import SNAC
 from peft import PeftModel
 
+# Ensure repo root is on the path when executed from ``scripts``
+import sys
+repo_root = os.path.dirname(os.path.dirname(__file__))
+if repo_root not in sys.path:
+    sys.path.insert(0, repo_root)
+
+from audio_utils import concat_with_fade
+
 CACHE_DIR = os.path.join(os.path.dirname(__file__), '..', 'models')
 
 def load_model(model_name, lora_path=None):
@@ -234,7 +242,7 @@ def main():
             audio_parts = [
                 generate_audio_segment(ids, model, snac_model) for ids in segments
             ]
-            final_audio = torch.cat(audio_parts, dim=-1)
+            final_audio = concat_with_fade(audio_parts)
             path = get_output_path(lora_choice or "base_model")
             torchaudio.save(path, final_audio.detach().cpu(), 24000)
             print(f"Audio written to {path}")


### PR DESCRIPTION
## Summary
- add utility `concat_with_fade` to concatenate generated audio segments smoothly
- use this helper in inference scripts and the gradio app
- ensure repo root is added to `sys.path` when running scripts so helpers can be imported

## Testing
- `python -m py_compile audio_utils.py gradio_app.py scripts/infer.py scripts/infer_interactive.py`

------
https://chatgpt.com/codex/tasks/task_e_68456d5010b083279136e686182ba0ad