### PR TITLE
Add configurable token length for dataset segments

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -53,7 +53,12 @@ def list_source_audio() -> list[str]:
     )
 
 
-def prepare_datasets_ui(upload_file: str, name: str, existing: list[str] | None) -> str:
+def prepare_datasets_ui(
+    upload_file: str,
+    name: str,
+    existing: list[str] | None,
+    max_tokens: int,
+) -> str:
     """Prepare one or more datasets from uploaded or existing audio files."""
     tasks: list[tuple[str, str]] = []
     if upload_file:
@@ -74,7 +79,7 @@ def prepare_datasets_ui(upload_file: str, name: str, existing: list[str] | None)
         out_dir = DATASETS_DIR / ds_name
         out_dir.parent.mkdir(parents=True, exist_ok=True)
         try:
-            prepare_dataset(audio_path, str(out_dir))
+            prepare_dataset(audio_path, str(out_dir), max_tokens=max_tokens)
             msgs.append(f"{ds_name}: success")
         except Exception as e:  # pragma: no cover - best effort
             msgs.append(f"{ds_name}: failed ({e})")
@@ -516,11 +521,12 @@ with gr.Blocks() as demo:
         audio_input = gr.Audio(type="filepath", label="Upload audio")
         local_audio = gr.Dropdown(choices=list_source_audio(), multiselect=True, label="Existing audio file(s)")
         dataset_name = gr.Textbox(label="Dataset Name (for upload)")
+        segment_tokens = gr.Number(value=50, precision=0, label="Max tokens per segment")
         prepare_btn = gr.Button("Prepare")
         prepare_output = gr.Textbox()
         prepare_btn.click(
             prepare_datasets_ui,
-            [audio_input, dataset_name, local_audio],
+            [audio_input, dataset_name, local_audio, segment_tokens],
             prepare_output,
         )
 

--- a/scripts/orpheus_cli.py
+++ b/scripts/orpheus_cli.py
@@ -23,8 +23,10 @@ def install():
 
 def create_dataset():
     multi = input("Create datasets in batch? (y/N): ").strip().lower() == "y"
+    max_tok_in = input("Max tokens per segment [50]: ").strip()
+    max_tokens = int(max_tok_in) if max_tok_in.isdigit() else 50
     while True:
-        run_script(["python", "prepare_dataset_interactive.py"])
+        run_script(["python", "prepare_dataset_interactive.py", "--max_tokens", str(max_tokens)])
         if not multi:
             break
         again = input("Create another dataset? (y/N): ").strip().lower()

--- a/scripts/prepare_dataset.py
+++ b/scripts/prepare_dataset.py
@@ -21,8 +21,18 @@ from tools.Whisper import run as whisper_run
 from tools.Whisper.upload import load_dataset_from_folder
 
 
-def prepare_dataset(audio_path: str, output_dir: str) -> None:
-    """Transcribe ``audio_path`` and save the dataset under ``output_dir``."""
+def prepare_dataset(audio_path: str, output_dir: str, max_tokens: int = 50) -> None:
+    """Transcribe ``audio_path`` and save the dataset under ``output_dir``.
+
+    Parameters
+    ----------
+    audio_path : str
+        Path to the source audio file.
+    output_dir : str
+        Directory where the dataset will be stored.
+    max_tokens : int, optional
+        Maximum number of tokens per audio segment. Defaults to 50.
+    """
     audio_path = Path(audio_path).resolve()
     base = audio_path.stem
     temp_out = Path("whisperx_out")
@@ -30,7 +40,12 @@ def prepare_dataset(audio_path: str, output_dir: str) -> None:
 
     # Run WhisperX transcription and segmentation
     json_path = whisper_run.run_whisperx(audio_path, temp_out)
-    whisper_run.segment_audio(audio_path, json_path, segment_out)
+    whisper_run.segment_audio(
+        audio_path,
+        json_path,
+        segment_out,
+        max_tokens=max_tokens,
+    )
 
     # Build Dataset and store it on disk
     dataset = load_dataset_from_folder(segment_out)
@@ -67,9 +82,15 @@ def main():
     parser = argparse.ArgumentParser(description="Transcribe audio and save as dataset")
     parser.add_argument("audio", help="Path to audio file (.mp3 or .wav)")
     parser.add_argument("output", help="Directory to save the dataset")
+    parser.add_argument(
+        "--max_tokens",
+        type=int,
+        default=50,
+        help="Maximum tokens per audio segment",
+    )
     args = parser.parse_args()
 
-    prepare_dataset(args.audio, args.output)
+    prepare_dataset(args.audio, args.output, max_tokens=args.max_tokens)
 
 
 if __name__ == "__main__":

--- a/scripts/prepare_dataset_interactive.py
+++ b/scripts/prepare_dataset_interactive.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from prepare_dataset import prepare_dataset
 
 
-def main() -> None:
+def main(max_tokens: int = 50) -> None:
     repo_root = Path(__file__).resolve().parent.parent
     audio_dir = repo_root / "source_audio"
     dataset_root = repo_root / "datasets"
@@ -40,14 +40,29 @@ def main() -> None:
     if not indices:
         indices = [1]
 
+    print(f"\nUsing {max_tokens} tokens per segment\n")
+
     for idx in indices:
         selected = audio_files[idx - 1]
         audio_path = audio_dir / selected
         output_dir = dataset_root / Path(selected).stem
-        prepare_dataset(str(audio_path), str(output_dir))
+        prepare_dataset(str(audio_path), str(output_dir), max_tokens=max_tokens)
         print(f"Dataset directory: {output_dir.resolve()}")
         print(f"Parquet file: {(output_dir / 'dataset.parquet').resolve()}")
 
 
 if __name__ == "__main__":
-    main()
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Interactively prepare datasets using WhisperX"
+    )
+    parser.add_argument(
+        "--max_tokens",
+        type=int,
+        default=50,
+        help="Maximum tokens per audio segment",
+    )
+    args = parser.parse_args()
+
+    main(max_tokens=args.max_tokens)


### PR DESCRIPTION
## Summary
- enable passing max token length to whisper segmentation
- expose new `--max_tokens` option in dataset preparation scripts
- prompt for tokens when creating datasets in `orpheus_cli`
- add slider to Gradio UI to set token length for dataset segments

## Testing
- `python -m py_compile scripts/prepare_dataset.py scripts/prepare_dataset_interactive.py scripts/orpheus_cli.py gradio_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6845d071e2e08327b5d1c25777c79526