### PR TITLE
Add model_max_len dataset option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ python scripts/orpheus_cli.py
 ## 🧩 Features
 
 - Install dependencies
-- Create WhisperX datasets
+- Create WhisperX datasets (``prepare_dataset.py`` now accepts ``--model_max_len`` to limit segment length)
 - Train LoRA models
 - Run inference
 

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -59,6 +59,7 @@ def prepare_datasets_ui(
     existing: list[str] | None,
     max_tokens: int,
     min_duration: float | None,
+    model_max_len: int,
 ) -> str:
     """Prepare one or more datasets from uploaded or existing audio files."""
     tasks: list[tuple[str, str]] = []
@@ -85,6 +86,7 @@ def prepare_datasets_ui(
                 str(out_dir),
                 max_tokens=max_tokens,
                 min_duration=min_duration,
+                model_max_len=model_max_len,
             )
             msgs.append(f"{ds_name}: success")
         except Exception as e:  # pragma: no cover - best effort
@@ -529,11 +531,19 @@ with gr.Blocks() as demo:
         dataset_name = gr.Textbox(label="Dataset Name (for upload)")
         segment_tokens = gr.Number(value=50, precision=0, label="Max tokens per segment")
         segment_duration = gr.Number(value=10, precision=1, label="Min seconds per segment")
+        model_max_len = gr.Number(value=2048, precision=0, label="Model max length")
         prepare_btn = gr.Button("Prepare")
         prepare_output = gr.Textbox()
         prepare_btn.click(
             prepare_datasets_ui,
-            [audio_input, dataset_name, local_audio, segment_tokens, segment_duration],
+            [
+                audio_input,
+                dataset_name,
+                local_audio,
+                segment_tokens,
+                segment_duration,
+                model_max_len,
+            ],
             prepare_output,
         )
 

--- a/scripts/orpheus_cli.py
+++ b/scripts/orpheus_cli.py
@@ -24,17 +24,36 @@ def install():
 def create_dataset():
     multi = input("Create datasets in batch? (y/N): ").strip().lower() == "y"
     use_dur = input("Segment by duration instead of tokens? (y/N): ").strip().lower() == "y"
+    model_len_in = input("Model max length [2048]: ").strip()
+    try:
+        model_max_len = int(model_len_in) if model_len_in else 2048
+    except ValueError:
+        model_max_len = 2048
     if use_dur:
         min_dur_in = input("Min seconds per segment [10]: ").strip()
         try:
             min_duration = float(min_dur_in) if min_dur_in else 10.0
         except ValueError:
             min_duration = 10.0
-        cmd = ["python", "prepare_dataset_interactive.py", "--min_duration", str(min_duration)]
+        cmd = [
+            "python",
+            "prepare_dataset_interactive.py",
+            "--min_duration",
+            str(min_duration),
+            "--model_max_len",
+            str(model_max_len),
+        ]
     else:
         max_tok_in = input("Max tokens per segment [50]: ").strip()
         max_tokens = int(max_tok_in) if max_tok_in.isdigit() else 50
-        cmd = ["python", "prepare_dataset_interactive.py", "--max_tokens", str(max_tokens)]
+        cmd = [
+            "python",
+            "prepare_dataset_interactive.py",
+            "--max_tokens",
+            str(max_tokens),
+            "--model_max_len",
+            str(model_max_len),
+        ]
     while True:
         run_script(cmd)
         if not multi:

--- a/scripts/prepare_dataset_interactive.py
+++ b/scripts/prepare_dataset_interactive.py
@@ -12,7 +12,11 @@ from pathlib import Path
 from prepare_dataset import prepare_dataset
 
 
-def main(max_tokens: int = 50, min_duration: float | None = None) -> None:
+def main(
+    max_tokens: int = 50,
+    min_duration: float | None = None,
+    model_max_len: int = 2048,
+) -> None:
     repo_root = Path(__file__).resolve().parent.parent
     audio_dir = repo_root / "source_audio"
     dataset_root = repo_root / "datasets"
@@ -54,6 +58,7 @@ def main(max_tokens: int = 50, min_duration: float | None = None) -> None:
             str(output_dir),
             max_tokens=max_tokens,
             min_duration=min_duration,
+            model_max_len=model_max_len,
         )
 
         print(f"Dataset directory: {output_dir.resolve()}")
@@ -77,6 +82,16 @@ if __name__ == "__main__":
         type=float,
         help="Minimum duration in seconds per segment",
     )
+    parser.add_argument(
+        "--model_max_len",
+        type=int,
+        default=2048,
+        help="Model max length used to estimate max audio duration",
+    )
     args = parser.parse_args()
 
-    main(max_tokens=args.max_tokens, min_duration=args.min_duration)
+    main(
+        max_tokens=args.max_tokens,
+        min_duration=args.min_duration,
+        model_max_len=args.model_max_len,
+    )


### PR DESCRIPTION
## Summary
- allow specifying `--model_max_len` when preparing datasets
- propagate `--model_max_len` to interactive prep, CLI, and Gradio UI
- compute max audio seconds from model length in `prepare_dataset`
- document dataset option in README

## Testing
- `python -m py_compile scripts/prepare_dataset.py scripts/prepare_dataset_interactive.py scripts/orpheus_cli.py gradio_app.py`


------
https://chatgpt.com/codex/tasks/task_e_6845e2960f288327a1b2b489a5676174