### PR TITLE
Implement sequence length checks

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -137,6 +137,14 @@ def create_input_ids(example):
     return example
 
 dataset = dataset.map(create_input_ids, remove_columns=['text', 'codes_list'])
+
+# Filter out samples that exceed the model sequence length
+before_len = len(dataset)
+dataset = dataset.filter(lambda x: len(x['input_ids']) <= 2048)
+skipped = before_len - len(dataset)
+if skipped:
+    print(f"Skipped {skipped} sample(s) exceeding 2048 tokens.")
+
 columns_to_keep = ['input_ids', 'labels', 'attention_mask']
 columns_to_remove = [col for col in dataset.column_names if col not in columns_to_keep]
 dataset = dataset.remove_columns(columns_to_remove)

--- a/scripts/train_interactive.py
+++ b/scripts/train_interactive.py
@@ -193,6 +193,14 @@ ensure that the dataset includes a 'source' field and format the input according
         return example
 
     dataset = dataset.map(create_input_ids, remove_columns=['text', 'codes_list'])
+
+    # Filter out samples that exceed the model sequence length
+    before_len = len(dataset)
+    dataset = dataset.filter(lambda x: len(x['input_ids']) <= 2048)
+    skipped = before_len - len(dataset)
+    if skipped:
+        print(f"Skipped {skipped} sample(s) exceeding 2048 tokens.")
+
     columns_to_keep = ['input_ids', 'labels', 'attention_mask']
     columns_to_remove = [col for col in dataset.column_names if col not in columns_to_keep]
     dataset = dataset.remove_columns(columns_to_remove)


### PR DESCRIPTION
## Summary
- filter out samples that exceed 2048 tokens when creating input ids
- print how many items were skipped

## Testing
- `python -m py_compile scripts/train_interactive.py scripts/train.py`

------
https://chatgpt.com/codex/tasks/task_e_6845e9ffcc1c8327910f118e40dc6ca6