### PR TITLE
docs: clarify segment length cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ python scripts/orpheus_cli.py
 - Create WhisperX datasets (``prepare_dataset.py`` now accepts ``--model_max_len`` to limit segment length)
 - Train LoRA models
 - Run inference
+- Long WhisperX segments may yield audio clips exceeding the model's context length. ``prepare_dataset.py`` now enforces a hard duration cap via ``--model_max_len`` and the training scripts skip samples that still surpass this limit.
 
 All features are available via an interactive command-line menu.
 


### PR DESCRIPTION
## Summary
- mention new behaviour around `model_max_len`
- clarify dataset capping behavior

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845ea028c808327b00d44741644f6f6