### PR TITLE
Add model_max_len training controls

### DIFF
--- a/scripts/orpheus_cli.py
+++ b/scripts/orpheus_cli.py
@@ -65,8 +65,13 @@ def create_dataset():
 
 def train():
     multi = input("Train multiple models? (y/N): ").strip().lower() == "y"
+    model_len_in = input("Model max length [2048]: ").strip()
+    try:
+        model_max_len = int(model_len_in) if model_len_in else 2048
+    except ValueError:
+        model_max_len = 2048
     while True:
-        run_script(["python", "train_interactive.py"])
+        run_script(["python", "train_interactive.py", "--model_max_len", str(model_max_len)])
         if not multi:
             break
         again = input("Train another model? (y/N): ").strip().lower()


### PR DESCRIPTION
## Summary
- enable configurable `model_max_len` for training scripts
- expose training max length option in the CLI
- skip overlong samples in Gradio training and allow setting max length

## Testing
- `python -m py_compile scripts/train_interactive.py gradio_app.py scripts/orpheus_cli.py scripts/train.py`

------
https://chatgpt.com/codex/tasks/task_e_6845eb9daef88327a6271ba03b81f0e6