### PR TITLE
Expose max token limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,7 @@ The web UI lets you prepare datasets, train LoRAs and run inference.
 Training and inference tabs include dropdowns listing local datasets or
 available LoRA models and can also load prompt lists from `prompt_list/`.
 
+The "Max New Tokens" setting defaults to 1200. The model has a 2048 token
+context limit, so the sum of prompt tokens and new tokens should not exceed
+this value.
+


### PR DESCRIPTION
## Summary
- allow generate_audio_segment to accept max_new_tokens and plumb through inference code
- add --max_tokens to inference scripts
- describe max token setting and 2048 token limit in docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python scripts/infer.py --help` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6845f180710c8327b4afad1c016806bd