### PR TITLE
Fix dataset max_len calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ python scripts/orpheus_cli.py
 ## 🧩 Features
 
 - Install dependencies
-- Create WhisperX datasets (``prepare_dataset.py`` now accepts ``--model_max_len`` to limit segment length)
+- Create WhisperX datasets (``prepare_dataset.py`` accepts ``--model_max_len`` to cap segment duration based on the model context)
 - Train LoRA models
 - Run inference
-- Long WhisperX segments may yield audio clips exceeding the model's context length. ``prepare_dataset.py`` now enforces a hard duration cap via ``--model_max_len`` and the training scripts skip samples that still surpass this limit.
+- Long WhisperX segments may yield audio clips exceeding the model's context length. ``prepare_dataset.py`` computes a duration cap from ``--model_max_len`` and training scripts skip samples that still surpass this limit.
 
 All features are available via an interactive command-line menu.
 
@@ -76,6 +76,8 @@ The script will ask which port you want to use before launching.
 The web UI lets you prepare datasets, train LoRAs and run inference.
 Training and inference tabs include dropdowns listing local datasets or
 available LoRA models and can also load prompt lists from `prompt_list/`.
+
+To let dataset segments stretch up to the context limit, set **Min seconds per segment** to `0` so the value from **Model max length** is used automatically.
 
 The "Max New Tokens" setting defaults to 1200. The model has a 2048 token
 context limit, so the sum of prompt tokens and new tokens should not exceed

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -85,7 +85,7 @@ def prepare_datasets_ui(
                 audio_path,
                 str(out_dir),
                 max_tokens=max_tokens,
-                min_duration=min_duration,
+                min_duration=min_duration if min_duration and min_duration > 0 else None,
                 model_max_len=model_max_len,
             )
             msgs.append(f"{ds_name}: success")
@@ -550,7 +550,7 @@ with gr.Blocks() as demo:
         local_audio = gr.Dropdown(choices=list_source_audio(), multiselect=True, label="Existing audio file(s)")
         dataset_name = gr.Textbox(label="Dataset Name (for upload)")
         segment_tokens = gr.Number(value=50, precision=0, label="Max tokens per segment")
-        segment_duration = gr.Number(value=10, precision=1, label="Min seconds per segment")
+        segment_duration = gr.Number(value=0, precision=1, label="Min seconds per segment (0 = auto)")
         model_max_len = gr.Number(value=2048, precision=0, label="Model max length")
         prepare_btn = gr.Button("Prepare")
         prepare_output = gr.Textbox()


### PR DESCRIPTION
## Summary
- let `prepare_dataset.py` extend segment duration to fit `--model_max_len`
- clarify dataset auto duration in Gradio UI
- document new 0 value for segment duration

## Testing
- `python scripts/check_env.py`
- `python -m py_compile scripts/prepare_dataset.py gradio_app.py`


------
https://chatgpt.com/codex/tasks/task_e_6845fab8b7888327b7a49aa949e2d9dd