### PR TITLE
Simplify dataset segmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ python scripts/orpheus_cli.py
 ## 🧩 Features
 
 - Install dependencies
-- Create WhisperX datasets (``prepare_dataset.py`` accepts ``--model_max_len`` to cap segment duration based on the model context)
+- Create WhisperX datasets with ~20 second segments
 - Train LoRA models
 - Run inference
-- Long WhisperX segments may yield audio clips exceeding the model's context length. ``prepare_dataset.py`` computes a duration cap from ``--model_max_len`` and training scripts skip samples that still surpass this limit.
+- Each audio fragment is automatically cut around 20 seconds without splitting words.
 
 All features are available via an interactive command-line menu.
 
@@ -76,8 +76,6 @@ The script will ask which port you want to use before launching.
 The web UI lets you prepare datasets, train LoRAs and run inference.
 Training and inference tabs include dropdowns listing local datasets or
 available LoRA models and can also load prompt lists from `prompt_list/`.
-
-To let dataset segments stretch up to the context limit, set **Min seconds per segment** to `0` so the value from **Model max length** is used automatically.
 
 The "Max New Tokens" setting defaults to 1200. The model has a 2048 token
 context limit, so the sum of prompt tokens and new tokens should not exceed

--- a/scripts/orpheus_cli.py
+++ b/scripts/orpheus_cli.py
@@ -23,37 +23,7 @@ def install():
 
 def create_dataset():
     multi = input("Create datasets in batch? (y/N): ").strip().lower() == "y"
-    use_dur = input("Segment by duration instead of tokens? (y/N): ").strip().lower() == "y"
-    model_len_in = input("Model max length [2048]: ").strip()
-    try:
-        model_max_len = int(model_len_in) if model_len_in else 2048
-    except ValueError:
-        model_max_len = 2048
-    if use_dur:
-        min_dur_in = input("Min seconds per segment [10]: ").strip()
-        try:
-            min_duration = float(min_dur_in) if min_dur_in else 10.0
-        except ValueError:
-            min_duration = 10.0
-        cmd = [
-            "python",
-            "prepare_dataset_interactive.py",
-            "--min_duration",
-            str(min_duration),
-            "--model_max_len",
-            str(model_max_len),
-        ]
-    else:
-        max_tok_in = input("Max tokens per segment [50]: ").strip()
-        max_tokens = int(max_tok_in) if max_tok_in.isdigit() else 50
-        cmd = [
-            "python",
-            "prepare_dataset_interactive.py",
-            "--max_tokens",
-            str(max_tokens),
-            "--model_max_len",
-            str(model_max_len),
-        ]
+    cmd = ["python", "prepare_dataset_interactive.py"]
     while True:
         run_script(cmd)
         if not multi:
@@ -65,13 +35,8 @@ def create_dataset():
 
 def train():
     multi = input("Train multiple models? (y/N): ").strip().lower() == "y"
-    model_len_in = input("Model max length [2048]: ").strip()
-    try:
-        model_max_len = int(model_len_in) if model_len_in else 2048
-    except ValueError:
-        model_max_len = 2048
     while True:
-        run_script(["python", "train_interactive.py", "--model_max_len", str(model_max_len)])
+        run_script(["python", "train_interactive.py"])
         if not multi:
             break
         again = input("Train another model? (y/N): ").strip().lower()

--- a/scripts/prepare_dataset_interactive.py
+++ b/scripts/prepare_dataset_interactive.py
@@ -12,11 +12,7 @@ from pathlib import Path
 from prepare_dataset import prepare_dataset
 
 
-def main(
-    max_tokens: int = 50,
-    min_duration: float | None = None,
-    model_max_len: int = 2048,
-) -> None:
+def main() -> None:
     repo_root = Path(__file__).resolve().parent.parent
     audio_dir = repo_root / "source_audio"
     dataset_root = repo_root / "datasets"
@@ -44,54 +40,15 @@ def main(
     if not indices:
         indices = [1]
 
-    if min_duration is not None:
-        print(f"\nUsing minimum {min_duration} seconds per segment\n")
-    else:
-        print(f"\nUsing {max_tokens} tokens per segment\n")
-
     for idx in indices:
         selected = audio_files[idx - 1]
         audio_path = audio_dir / selected
         output_dir = dataset_root / Path(selected).stem
-        prepare_dataset(
-            str(audio_path),
-            str(output_dir),
-            max_tokens=max_tokens,
-            min_duration=min_duration,
-            model_max_len=model_max_len,
-        )
+        prepare_dataset(str(audio_path), str(output_dir))
 
         print(f"Dataset directory: {output_dir.resolve()}")
         print(f"Parquet file: {(output_dir / 'dataset.parquet').resolve()}")
 
 
 if __name__ == "__main__":
-    import argparse
-
-    parser = argparse.ArgumentParser(
-        description="Interactively prepare datasets using WhisperX"
-    )
-    parser.add_argument(
-        "--max_tokens",
-        type=int,
-        default=50,
-        help="Maximum tokens per audio segment",
-    )
-    parser.add_argument(
-        "--min_duration",
-        type=float,
-        help="Minimum duration in seconds per segment",
-    )
-    parser.add_argument(
-        "--model_max_len",
-        type=int,
-        default=2048,
-        help="Model max length used to estimate max audio duration",
-    )
-    args = parser.parse_args()
-
-    main(
-        max_tokens=args.max_tokens,
-        min_duration=args.min_duration,
-        model_max_len=args.model_max_len,
-    )
+    main()

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -10,15 +10,9 @@ from transformers import TrainingArguments, Trainer
 
 # Parse CLI arguments
 parser = argparse.ArgumentParser(description="Train a LoRA model")
-parser.add_argument(
-    "--model_max_len",
-    type=int,
-    default=2048,
-    help="Model max length used for dataset filtering",
-)
-args = parser.parse_args()
+args = parser.parse_args([])
 
-MODEL_MAX_LEN = args.model_max_len
+MODEL_MAX_LEN = 2048
 
 # Load model and tokenizer
 MODEL_NAME = os.environ.get("MODEL_NAME", "unsloth/orpheus-3b-0.1-ft")

--- a/tools/Whisper/run.py
+++ b/tools/Whisper/run.py
@@ -132,10 +132,10 @@ def segment_audio(
     audio_path,
     json_file,
     output_dir,
-    min_len=10.0,
-    max_len=15.0,
-    max_tokens=50,
-    target_samples=None,
+    min_len=20.0,
+    max_len=20.0,
+    max_tokens=9999,
+    target_samples=480000,
 ):
     """Cut ``audio_path`` into smaller clips based on WhisperX segments.
 


### PR DESCRIPTION
## Summary
- cut audio into ~20s fragments without splitting words
- drop token/duration arguments from dataset tools and CLI
- streamline training scripts
- hide segmentation controls in Gradio interface

## Testing
- `python -m py_compile gradio_app.py scripts/orpheus_cli.py scripts/prepare_dataset.py scripts/prepare_dataset_interactive.py scripts/train.py scripts/train_interactive.py tools/Whisper/run.py`

------
https://chatgpt.com/codex/tasks/task_e_6846000b776c8327b940572cbbdbf921