### PR TITLE
Update segmentation to 50 tokens

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -352,7 +352,7 @@ def get_snac_model():
     return _SNAC_MODEL
 
 
-def split_prompt_by_tokens(text: str, tokenizer, chunk_size: int = 30) -> list[torch.Tensor]:
+def split_prompt_by_tokens(text: str, tokenizer, chunk_size: int = 50) -> list[torch.Tensor]:
     """Split text into token chunks without cutting words."""
     words = text.split()
     segments: list[str] = []
@@ -576,7 +576,7 @@ with gr.Blocks() as demo:
             top_p = gr.Slider(0.5, 1.0, value=0.95, label="Top P")
             rep_penalty = gr.Slider(1.0, 2.0, value=1.1, label="Repetition Penalty")
             max_tokens = gr.Number(value=1200, precision=0, label="Max New Tokens")
-            segment_chk = gr.Checkbox(label="Segment text by 30 tokens")
+            segment_chk = gr.Checkbox(label="Segment text by 50 tokens")
         infer_btn = gr.Button("Generate")
         clear_btn = gr.Button("Clear Gallery")
         gallery = gr.HTML(label="Outputs")

--- a/scripts/infer.py
+++ b/scripts/infer.py
@@ -32,7 +32,7 @@ def load_model(model_name, lora_path=None):
     return model, tokenizer
 
 
-def split_prompt_by_tokens(text: str, tokenizer, chunk_size: int = 30) -> list[torch.Tensor]:
+def split_prompt_by_tokens(text: str, tokenizer, chunk_size: int = 50) -> list[torch.Tensor]:
     """Split text into token chunks without breaking words."""
     words = text.split()
     segments: list[str] = []
@@ -122,7 +122,7 @@ def main():
     parser = argparse.ArgumentParser(description='Interactive Orpheus TTS inference')
     parser.add_argument('--model', default='unsloth/orpheus-3b-0.1-ft', help='Model name or path')
     parser.add_argument('--lora', default='lora_model', help='Path to trained LoRA adapters')
-    parser.add_argument('--segment', action='store_true', help='Segment prompts every 30 tokens')
+    parser.add_argument('--segment', action='store_true', help='Segment prompts every 50 tokens')
     parser.add_argument(
         '--max_tokens',
         type=int,

--- a/scripts/infer_interactive.py
+++ b/scripts/infer_interactive.py
@@ -51,7 +51,7 @@ def get_output_path(lora_name: str, ext: str = ".wav") -> str:
         idx += 1
 
 
-def split_prompt_by_tokens(text: str, tokenizer, chunk_size: int = 30) -> list[torch.Tensor]:
+def split_prompt_by_tokens(text: str, tokenizer, chunk_size: int = 50) -> list[torch.Tensor]:
     """Split text into token chunks without breaking words."""
     words = text.split()
     segments: list[str] = []
@@ -143,7 +143,7 @@ def main():
     parser.add_argument(
         "--segment",
         action="store_true",
-        help="Segment prompts every 30 tokens",
+        help="Segment prompts every 50 tokens",
     )
     parser.add_argument(
         "--max_tokens",
@@ -237,7 +237,7 @@ def main():
         segment_choice = True
     else:
         segment_choice = (
-            input("Segment prompts every 30 tokens? (y/N): ").strip().lower()
+            input("Segment prompts every 50 tokens? (y/N): ").strip().lower()
             == "y"
         )
 

--- a/scripts/orpheus_cli.py
+++ b/scripts/orpheus_cli.py
@@ -46,7 +46,7 @@ def train():
 
 def infer():
     multi = input("Run inference on multiple models? (y/N): ").strip().lower() == "y"
-    segment = input("Segment prompts every 30 tokens? (y/N): ").strip().lower() == "y"
+    segment = input("Segment prompts every 50 tokens? (y/N): ").strip().lower() == "y"
     cmd = ["python", "infer_interactive.py"]
     if segment:
         cmd.append("--segment")


### PR DESCRIPTION
## Summary
- change default chunk size in `split_prompt_by_tokens` from 30 to 50
- update CLI and Gradio text to match new default

## Testing
- `python -m py_compile scripts/infer.py scripts/infer_interactive.py scripts/orpheus_cli.py gradio_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68460ef95060832799f76af72f2623d3