### PR TITLE
Add sentence-based segmentation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,10 @@ The "Max New Tokens" setting defaults to 1200. The model has a 2048 token
 context limit, so the sum of prompt tokens and new tokens should not exceed
 this value.
 
+### Prompt Segmentation
+
+Long prompts can be split automatically during inference to avoid hitting the
+token limit. Use `--segment` along with `--segment-by tokens` (default) or
+`--segment-by sentence` to control how text is chunked. Sentence segmentation
+usually produces smoother audio because pauses occur at natural boundaries.
+


### PR DESCRIPTION
## Summary
- implement `split_prompt_by_sentences` helpers
- add `--segment-by` option to CLI scripts
- extend Gradio UI with segmentation mode selector
- document new segmentation approach for smoother audio

## Testing
- `python -m py_compile scripts/infer.py scripts/infer_interactive.py gradio_app.py`

------
https://chatgpt.com/codex/tasks/task_e_684615c871ec8327aee19c49d402597a