### PR TITLE
Allow comma-based segmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,4 +87,8 @@ Long prompts can be split automatically during inference to avoid hitting the
 token limit. Use `--segment` along with `--segment-by tokens` (default) or
 `--segment-by sentence` to control how text is chunked. Sentence segmentation
 usually produces smoother audio because pauses occur at natural boundaries.
+When splitting by sentences, commas are also considered separators. The
+algorithm ignores consecutive commas and merges pieces shorter than three words
+with their neighbors so lists or short phrases aren't broken awkwardly. Enable
+sentence segmentation for long prompts with natural pause points.
 

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -377,7 +377,15 @@ def split_prompt_by_sentences(
     text: str, tokenizer, chunk_size: int = 50
 ) -> list[torch.Tensor]:
     """Split text into sentence groups not exceeding ``chunk_size`` tokens."""
-    sentences = [s.strip() for s in re.split(r"(?<=[.!?])\s+", text.strip()) if s.strip()]
+    raw_parts = [s.strip() for s in re.split(r"(?<=[.!?,])\s+", text.strip()) if s.strip()]
+    sentences: list[str] = []
+    for part in raw_parts:
+        if sentences:
+            prev = sentences[-1]
+            if prev.endswith(",") and (part.endswith(",") or len(part.split()) < 3):
+                sentences[-1] = prev + " " + part
+                continue
+        sentences.append(part)
     segments: list[str] = []
     current: list[str] = []
     for sent in sentences:

--- a/scripts/infer.py
+++ b/scripts/infer.py
@@ -57,7 +57,15 @@ def split_prompt_by_sentences(
     text: str, tokenizer, chunk_size: int = 50
 ) -> list[torch.Tensor]:
     """Split text into sentence groups not exceeding ``chunk_size`` tokens."""
-    sentences = [s.strip() for s in re.split(r"(?<=[.!?])\s+", text.strip()) if s.strip()]
+    raw_parts = [s.strip() for s in re.split(r"(?<=[.!?,])\s+", text.strip()) if s.strip()]
+    sentences: list[str] = []
+    for part in raw_parts:
+        if sentences:
+            prev = sentences[-1]
+            if prev.endswith(",") and (part.endswith(",") or len(part.split()) < 3):
+                sentences[-1] = prev + " " + part
+                continue
+        sentences.append(part)
     segments: list[str] = []
     current: list[str] = []
     for sent in sentences:

--- a/scripts/infer_interactive.py
+++ b/scripts/infer_interactive.py
@@ -76,7 +76,15 @@ def split_prompt_by_sentences(
     text: str, tokenizer, chunk_size: int = 50
 ) -> list[torch.Tensor]:
     """Split text into sentence groups up to ``chunk_size`` tokens."""
-    sentences = [s.strip() for s in re.split(r"(?<=[.!?])\s+", text.strip()) if s.strip()]
+    raw_parts = [s.strip() for s in re.split(r"(?<=[.!?,])\s+", text.strip()) if s.strip()]
+    sentences: list[str] = []
+    for part in raw_parts:
+        if sentences:
+            prev = sentences[-1]
+            if prev.endswith(",") and (part.endswith(",") or len(part.split()) < 3):
+                sentences[-1] = prev + " " + part
+                continue
+        sentences.append(part)
     segments: list[str] = []
     current: list[str] = []
     for sent in sentences:


### PR DESCRIPTION
## Summary
- improve sentence segmentation functions so commas can split text
- ignore consecutive commas and very short fragments when segmenting
- document the updated splitting logic

## Testing
- `python -m py_compile scripts/infer.py scripts/infer_interactive.py gradio_app.py`

------
https://chatgpt.com/codex/tasks/task_e_68461a41eec88327860fc05ec961fc3c