### PR TITLE
Add segmentation logging

### DIFF
--- a/scripts/infer_interactive.py
+++ b/scripts/infer_interactive.py
@@ -52,7 +52,12 @@ def get_output_path(lora_name: str, ext: str = ".wav") -> str:
         idx += 1
 
 
-def split_prompt_by_tokens(text: str, tokenizer, chunk_size: int = 50) -> list[torch.Tensor]:
+def split_prompt_by_tokens(
+    text: str,
+    tokenizer,
+    chunk_size: int = 50,
+    return_text: bool = False,
+) -> list[torch.Tensor] | tuple[list[str], list[torch.Tensor]]:
     """Split text into token chunks without breaking words."""
     words = text.split()
     segments: list[str] = []
@@ -69,12 +74,27 @@ def split_prompt_by_tokens(text: str, tokenizer, chunk_size: int = 50) -> list[t
             token_len += n_tokens
     if current:
         segments.append(" ".join(current))
-    return [tokenizer(s, return_tensors="pt").input_ids.squeeze(0) for s in segments]
+    token_segments = [tokenizer(s, return_tensors="pt").input_ids.squeeze(0) for s in segments]
+    return (segments, token_segments) if return_text else token_segments
+
+
+def print_segment_log(prompt: str, segments: list[str]) -> None:
+    """Print segment boundaries for a prompt."""
+    print("Segmentation log:")
+    offset = 0
+    for idx, seg in enumerate(segments, 1):
+        start = prompt.find(seg, offset)
+        end = start + len(seg)
+        print(f"{idx}: chars {start}-{end}: {seg}")
+        offset = end
 
 
 def split_prompt_by_sentences(
-    text: str, tokenizer, chunk_size: int = 50
-) -> list[torch.Tensor]:
+    text: str,
+    tokenizer,
+    chunk_size: int = 50,
+    return_text: bool = False,
+) -> list[torch.Tensor] | tuple[list[str], list[torch.Tensor]]:
     """Split text into sentence groups up to ``chunk_size`` tokens."""
     raw_parts = [s.strip() for s in re.split(r"(?<=[.!?,])\s+", text.strip()) if s.strip()]
     sentences: list[str] = []
@@ -97,7 +117,8 @@ def split_prompt_by_sentences(
             current.append(sent)
     if current:
         segments.append(" ".join(current))
-    return [tokenizer(s, return_tensors="pt").input_ids.squeeze(0) for s in segments]
+    token_segments = [tokenizer(s, return_tensors="pt").input_ids.squeeze(0) for s in segments]
+    return (segments, token_segments) if return_text else token_segments
 
 
 def generate_audio_segment(
@@ -282,9 +303,10 @@ def main():
         for text in prompts:
             if segment_choice:
                 if args.segment_by == "sentence":
-                    segments = split_prompt_by_sentences(text, tokenizer)
+                    seg_text, segments = split_prompt_by_sentences(text, tokenizer, return_text=True)
                 else:
-                    segments = split_prompt_by_tokens(text, tokenizer)
+                    seg_text, segments = split_prompt_by_tokens(text, tokenizer, return_text=True)
+                print_segment_log(text, seg_text)
             else:
                 segments = [tokenizer(text, return_tensors="pt").input_ids.squeeze(0)]
             audio_parts = [


### PR DESCRIPTION
## Summary
- add text-returning segment functions and print logs
- output segmentation log in CLI, interactive, and Gradio interfaces

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684625c49eac8327aaf8a00fd2b27f57