### PR TITLE
Improve logging across CLI and Gradio interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ python scripts/orpheus_cli.py
 - The dataset helper lists audio files from `source_audio/` so you can pick them interactively
 - Segmentation mode prints the start and end index of each chunk so you know where text was split
 - Trained LoRA adapters are stored under `scripts/lora_models/<dataset>/lora_model`
+- Detailed logs for the CLI and Gradio interface are saved under `logs/orpheus.log`
 
 All features are available via an interactive command-line menu.
 
@@ -91,6 +92,11 @@ available LoRA models and can also load prompt lists from `prompt_list/`.
 The "Max New Tokens" setting defaults to 1200. The model has a 2048 token
 context limit, so the sum of prompt tokens and new tokens should not exceed
 this value.
+
+The interface offers two presets under "Advanced Settings": **Short Audio**
+and **Long Audio**. The short preset keeps segmentation disabled and limits
+new tokens to 1200, while the long preset enables sentence segmentation and
+allows up to 2400 new tokens.
 
 ### Prompt Segmentation
 

--- a/scripts/orpheus_cli.py
+++ b/scripts/orpheus_cli.py
@@ -2,19 +2,29 @@
 """Simple interactive CLI to manage OrpheusX workflows."""
 import os
 import subprocess
+import time
 from pathlib import Path
+from tools.logger_utils import get_logger
 
 # Resolve repository root based on script location
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPTS_DIR = REPO_ROOT / "scripts"
 
+logger = get_logger("orpheus_cli")
+
 
 def run_script(command, shell=False):
-    """Run a command as subprocess and stream its output."""
+    """Run a command as subprocess and stream its output with logging."""
+    cmd_str = command if isinstance(command, str) else " ".join(command)
+    logger.info("Running: %s", cmd_str)
+    start = time.perf_counter()
     try:
         subprocess.run(command, check=True, cwd=str(SCRIPTS_DIR), shell=shell)
+        elapsed = time.perf_counter() - start
+        logger.info("Finished in %.2fs", elapsed)
     except subprocess.CalledProcessError as exc:
-        print(f"Command failed: {exc}")
+        elapsed = time.perf_counter() - start
+        logger.error("Command failed after %.2fs: %s", elapsed, exc)
 
 
 def install():
@@ -81,7 +91,8 @@ def main() -> None:
         if not action:
             print("Invalid option")
             continue
-        _, func = action
+        label, func = action
+        logger.info("Selected option: %s", label)
         func()
 
 

--- a/tools/logger_utils.py
+++ b/tools/logger_utils.py
@@ -1,0 +1,22 @@
+import logging
+from pathlib import Path
+
+LOG_DIR = Path(__file__).resolve().parent.parent / "logs"
+LOG_DIR.mkdir(parents=True, exist_ok=True)
+LOG_FILE = LOG_DIR / "orpheus.log"
+
+
+def get_logger(name: str = "orpheus") -> logging.Logger:
+    """Return a logger writing to both console and file."""
+    logger = logging.getLogger(name)
+    if logger.handlers:
+        return logger
+    logger.setLevel(logging.INFO)
+    fmt = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+    file_handler = logging.FileHandler(LOG_FILE, encoding="utf-8")
+    file_handler.setFormatter(fmt)
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(fmt)
+    logger.addHandler(file_handler)
+    logger.addHandler(console_handler)
+    return logger


### PR DESCRIPTION
## Summary
- add reusable logging helper writing to `logs/orpheus.log`
- instrument `orpheus_cli` to log executed commands and menu choices
- add detailed execution and error logging in `gradio_app`
- document the log file location in the README
- add Short/Long audio presets in Gradio inference

## Testing
- `python -m pytest -q`
- `python -m py_compile scripts/orpheus_cli.py gradio_app.py tools/logger_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6846f5abb480832795b94f3ed51d27bf