### PR TITLE
Allow advanced training options in Gradio

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,12 @@ allows up to 2400 new tokens.
 ### Prompt Segmentation
 
 Long prompts can be split automatically during inference to avoid hitting the
-token limit. Use `--segment` along with `--segment-by tokens` (default) or
-`--segment-by sentence` to control how text is chunked. Sentence segmentation
-usually produces smoother audio because pauses occur at natural boundaries.
-When splitting by sentences, commas are also considered separators. The
+token limit. Use `--segment` along with `--segment-by tokens` (default),
+`--segment-by sentence`, or `--segment-by full_segment` to control how text is
+chunked. Sentence segmentation usually produces smoother audio because pauses
+occur at natural boundaries. The `full_segment` mode splits on every comma,
+period, question mark or exclamation point, producing the smallest possible
+chunks. When splitting by sentences, commas are also considered separators. The
 algorithm ignores consecutive commas and merges pieces shorter than three words
 with their neighbors so lists or short phrases aren't broken awkwardly. Enable
 sentence segmentation for long prompts with natural pause points.

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -11,6 +11,7 @@ import os
 from pathlib import Path
 import json
 import re
+import unsloth  # must be imported before transformers
 import gradio as gr
 import gc
 import time
@@ -118,6 +119,16 @@ def train_lora_single(
     dataset_source: str,
     lora_name: str,
     is_local: bool,
+    batch_size: int = 1,
+    grad_steps: int = 4,
+    warm_steps: int = 5,
+    max_steps: int = 60,
+    epochs: int = 1,
+    lr: float = 2e-4,
+    log_steps: int = 1,
+    weight_decay: float = 0.01,
+    optim: str = "adamw_8bit",
+    scheduler: str = "linear",
 ) -> str:
     """Train a single LoRA on a dataset."""
     logger.info("Training LoRA %s from %s", lora_name, dataset_source)
@@ -255,17 +266,18 @@ def train_lora_single(
         model=model,
         train_dataset=dataset,
         args=TrainingArguments(
-            per_device_train_batch_size=1,
-            gradient_accumulation_steps=4,
-            warmup_steps=5,
-            max_steps=60,
-            learning_rate=2e-4,
+            per_device_train_batch_size=batch_size,
+            gradient_accumulation_steps=grad_steps,
+            warmup_steps=warm_steps,
+            max_steps=max_steps,
+            num_train_epochs=epochs,
+            learning_rate=lr,
             fp16=not is_bfloat16_supported(),
             bf16=is_bfloat16_supported(),
-            logging_steps=1,
-            optim="adamw_8bit",
-            weight_decay=0.01,
-            lr_scheduler_type="linear",
+            logging_steps=log_steps,
+            optim=optim,
+            weight_decay=weight_decay,
+            lr_scheduler_type=scheduler,
             seed=3407,
             output_dir="outputs",
             report_to="none",
@@ -281,7 +293,20 @@ def train_lora_single(
     return f"LoRA saved under {save_dir.resolve()}"
 
 
-def train_loras(hf_links: str, local_datasets: list[str]) -> str:
+def train_loras(
+    hf_links: str,
+    local_datasets: list[str],
+    batch_size: int,
+    grad_steps: int,
+    warm_steps: int,
+    max_steps: int,
+    epochs: int,
+    lr: float,
+    log_steps: int,
+    weight_decay: float,
+    optim: str,
+    scheduler: str,
+) -> str:
     """Train one or more LoRAs based on the provided sources."""
     dataset_info: list[tuple[str, str, bool]] = []
     links = [l.strip() for l in hf_links.splitlines() if l.strip()]
@@ -300,7 +325,21 @@ def train_loras(hf_links: str, local_datasets: list[str]) -> str:
         progress((idx - 1) / total, desc=f"Training {name}...")
         start = time.perf_counter()
         try:
-            msg = train_lora_single(src, name, is_local)
+            msg = train_lora_single(
+                src,
+                name,
+                is_local,
+                batch_size,
+                grad_steps,
+                warm_steps,
+                max_steps,
+                epochs,
+                lr,
+                log_steps,
+                weight_decay,
+                optim,
+                scheduler,
+            )
             msgs.append(f"{name}: success")
             elapsed = time.perf_counter() - start
             logger.info("%s trained in %.2fs", name, elapsed)
@@ -409,6 +448,30 @@ def print_segment_log(prompt: str, segments: list[str]) -> None:
         end = start + len(seg)
         logger.info("%d: chars %d-%d: %s", idx, start, end, seg)
         offset = end
+
+
+def split_prompt_full(
+    text: str,
+    tokenizer,
+    chunk_size: int = 50,
+    return_text: bool = False,
+) -> list[torch.Tensor] | tuple[list[str], list[torch.Tensor]]:
+    """Split text at every punctuation mark and group into chunks."""
+    parts = [p.strip() for p in re.findall(r"[^,.!?]+[,.!?]?", text.strip()) if p.strip()]
+    segments: list[str] = []
+    current: list[str] = []
+    for part in parts:
+        candidate = " ".join(current + [part])
+        token_len = len(tokenizer(candidate, add_special_tokens=False).input_ids)
+        if token_len > chunk_size and current:
+            segments.append(" ".join(current))
+            current = [part]
+        else:
+            current.append(part)
+    if current:
+        segments.append(" ".join(current))
+    token_segments = [tokenizer(s, return_tensors="pt").input_ids.squeeze(0) for s in segments]
+    return (segments, token_segments) if return_text else token_segments
 
 
 def split_prompt_by_sentences(
@@ -536,6 +599,8 @@ def generate_audio(
     if segment:
         if segment_by == "sentence":
             seg_text, segments = split_prompt_by_sentences(text, tokenizer, return_text=True)
+        elif segment_by == "full_segment":
+            seg_text, segments = split_prompt_full(text, tokenizer, return_text=True)
         else:
             seg_text, segments = split_prompt_by_tokens(text, tokenizer, return_text=True)
         print_segment_log(text, seg_text)
@@ -667,9 +732,37 @@ with gr.Blocks() as demo:
         hf_input = gr.Textbox(label="HF dataset link (one per line)")
         local_ds = gr.Dropdown(choices=dataset_choices, multiselect=True, label="Local dataset(s)")
         model_max_len_train = gr.Number(value=2048, precision=0, label="Model max length", visible=False)
+        with gr.Accordion("Ajustes avanzados", open=False):
+            batch_size = gr.Number(value=1, precision=0, label="Batch size")
+            grad_steps = gr.Number(value=4, precision=0, label="Gradient accumulation")
+            warmup_steps = gr.Number(value=5, precision=0, label="Warmup steps")
+            max_steps = gr.Number(value=60, precision=0, label="Max steps")
+            epochs = gr.Number(value=1, precision=0, label="Epochs")
+            lr = gr.Number(value=2e-4, label="Learning rate")
+            log_steps = gr.Number(value=1, precision=0, label="Logging steps")
+            weight_decay = gr.Number(value=0.01, label="Weight decay")
+            optim = gr.Textbox(value="adamw_8bit", label="Optimizer")
+            scheduler = gr.Textbox(value="linear", label="LR scheduler type")
         train_btn = gr.Button("Train")
         train_output = gr.Textbox()
-        train_btn.click(train_loras, [hf_input, local_ds], train_output)
+        train_btn.click(
+            train_loras,
+            [
+                hf_input,
+                local_ds,
+                batch_size,
+                grad_steps,
+                warmup_steps,
+                max_steps,
+                epochs,
+                lr,
+                log_steps,
+                weight_decay,
+                optim,
+                scheduler,
+            ],
+            train_output,
+        )
 
     with gr.Tab("Inference"):
         mode = gr.Radio(["Manual", "Prompt List"], value="Manual", label="Prompt source")
@@ -688,7 +781,11 @@ with gr.Blocks() as demo:
             rep_penalty = gr.Slider(1.0, 2.0, value=1.1, label="Repetition Penalty")
             max_tokens = gr.Number(value=1200, precision=0, label="Max New Tokens")
             segment_chk = gr.Checkbox(label="Segment text")
-            segment_method = gr.Radio(["tokens", "sentence"], value="tokens", label="Segment by")
+            segment_method = gr.Radio([
+                "tokens",
+                "sentence",
+                "full_segment",
+            ], value="tokens", label="Segment by")
 
             def apply_profile(preset):
                 if preset == "Long Audio":


### PR DESCRIPTION
## Summary
- add advanced training settings section in the Train LoRA tab
- pass training parameters from the UI to the trainer
- import `unsloth` before transformers
- allow choosing `full_segment` mode in inference for punctuation-based splitting

## Testing
- `find . -name "*.py" | xargs python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_684707c93dcc832787130ffc6a1f87a7