### PR TITLE
Allow advanced training options in Gradio

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,12 @@ allows up to 2400 new tokens.
 ### Prompt Segmentation
 
 Long prompts can be split automatically during inference to avoid hitting the
-token limit. Use `--segment` along with `--segment-by tokens` (default) or
-`--segment-by sentence` to control how text is chunked. Sentence segmentation
-usually produces smoother audio because pauses occur at natural boundaries.
-When splitting by sentences, commas are also considered separators. The
+token limit. Use `--segment` along with `--segment-by tokens` (default),
+`--segment-by sentence`, or `--segment-by full_segment` to control how text is
+chunked. Sentence segmentation usually produces smoother audio because pauses
+occur at natural boundaries. The `full_segment` mode splits on every comma,
+period, question mark or exclamation point, producing the smallest possible
+chunks. When splitting by sentences, commas are also considered separators. The
 algorithm ignores consecutive commas and merges pieces shorter than three words
 with their neighbors so lists or short phrases aren't broken awkwardly. Enable
 sentence segmentation for long prompts with natural pause points.


### PR DESCRIPTION
## Summary
- add advanced training settings section in the Train LoRA tab
- pass training parameters from the UI to the trainer
- import `unsloth` before transformers
- allow choosing `full_segment` mode in inference for punctuation-based splitting
- handle consecutive punctuation in `full_segment`

## Testing
- `find . -name "*.py" | xargs python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_684707c93dcc832787130ffc6a1f87a7