### PR TITLE
Add segment gap option

### DIFF
--- a/audio_utils.py
+++ b/audio_utils.py
@@ -1,6 +1,6 @@
 import torch
 
-def concat_with_fade(chunks, sample_rate=24000, fade_ms=20):
+def concat_with_fade(chunks, sample_rate=24000, fade_ms=20, gap_ms=0):
     """Concatenate audio tensors with a short crossfade.
 
 
@@ -13,6 +13,8 @@ def concat_with_fade(chunks, sample_rate=24000, fade_ms=20):
         Sample rate of the audio, by default 24000.
     fade_ms : int, optional
         Duration of the crossfade in milliseconds, by default 20.
+    gap_ms : int, optional
+        Silence inserted between chunks in milliseconds, by default 0.
     Returns
     -------
     torch.Tensor
@@ -24,25 +26,47 @@ def concat_with_fade(chunks, sample_rate=24000, fade_ms=20):
         return chunks[0]
 
     fade_samples = int(sample_rate * fade_ms / 1000)
+    gap_samples = int(sample_rate * gap_ms / 1000)
     output = chunks[0]
     for chunk in chunks[1:]:
         overlap = (
             min(fade_samples, output.shape[-1], chunk.shape[-1]) if fade_samples > 0 else 0
         )
-        if overlap > 0:
-            fade_out = torch.linspace(1.0, 0.0, overlap, device=output.device, dtype=output.dtype)
-            fade_in = torch.linspace(0.0, 1.0, overlap, device=chunk.device, dtype=chunk.dtype)
-            if output.dim() == 2:
-                fade_out = fade_out.unsqueeze(0)
-            if chunk.dim() == 2:
-                fade_in = fade_in.unsqueeze(0)
-            mixed = output[..., -overlap:] * fade_out + chunk[..., :overlap] * fade_in
-            output = torch.cat([
-                output[..., :-overlap],
-                mixed,
-                chunk[..., overlap:],
-            ], dim=-1)
+        if gap_samples > 0:
+            silence_shape = list(output.shape)
+            silence_shape[-1] = gap_samples
+            silence = torch.zeros(silence_shape, dtype=output.dtype, device=output.device)
+            if overlap > 0:
+                fade_out = torch.linspace(1.0, 0.0, overlap, device=output.device, dtype=output.dtype)
+                fade_in = torch.linspace(0.0, 1.0, overlap, device=chunk.device, dtype=chunk.dtype)
+                if output.dim() == 2:
+                    fade_out = fade_out.unsqueeze(0)
+                if chunk.dim() == 2:
+                    fade_in = fade_in.unsqueeze(0)
+                output = torch.cat([
+                    output[..., :-overlap],
+                    output[..., -overlap:] * fade_out,
+                    silence,
+                    chunk[..., :overlap] * fade_in,
+                    chunk[..., overlap:],
+                ], dim=-1)
+            else:
+                output = torch.cat([output, silence, chunk], dim=-1)
         else:
-            output = torch.cat([output, chunk], dim=-1)
+            if overlap > 0:
+                fade_out = torch.linspace(1.0, 0.0, overlap, device=output.device, dtype=output.dtype)
+                fade_in = torch.linspace(0.0, 1.0, overlap, device=chunk.device, dtype=chunk.dtype)
+                if output.dim() == 2:
+                    fade_out = fade_out.unsqueeze(0)
+                if chunk.dim() == 2:
+                    fade_in = fade_in.unsqueeze(0)
+                mixed = output[..., -overlap:] * fade_out + chunk[..., :overlap] * fade_in
+                output = torch.cat([
+                    output[..., :-overlap],
+                    mixed,
+                    chunk[..., overlap:],
+                ], dim=-1)
+            else:
+                output = torch.cat([output, chunk], dim=-1)
 
     return output


### PR DESCRIPTION
## Summary
- allow defining a silent gap when concatenating segments
- expose `Gap between segments (s)` in the inference UI

## Testing
- `python -m py_compile audio_utils.py gradio_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6847215230888327aa2513866191880c