### PR TITLE
Remove audio gap from Auto Pipeline

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -816,7 +816,7 @@ def run_full_pipeline(dataset_file: str, prompt: str) -> tuple[str, str]:
             seg_chars=[",", ".", "?", "!"],
             seg_min_tokens=0,
             seg_max_tokens=50,
-            seg_gap=0.5,
+            seg_gap=0.0,
         )
     else:
         out_path = generate_audio(prompt, ds_name)


### PR DESCRIPTION
## Summary
- set `seg_gap` to 0.0 in `run_full_pipeline`

## Testing
- `python -m py_compile gradio_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6847f47925ec8327b1d4fd5d44fbf521