### PR TITLE
Fix full_segment segmentation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,14 +106,16 @@ token limit. Use `--segment` along with `--segment-by tokens` (default),
 chunked. Sentence segmentation usually produces smoother audio because pauses
 occur at natural boundaries. The `full_segment` mode splits on every comma,
 period, question mark or exclamation point, producing the smallest possible
-chunks. When splitting by sentences, commas are also considered separators. The
+chunks and ignoring the token count settings. When splitting by sentences,
+commas are also considered separators. The
 algorithm ignores consecutive commas and merges pieces shorter than three words
 with their neighbors so lists or short phrases aren't broken awkwardly. Enable
 sentence segmentation for long prompts with natural pause points.
 
 The Gradio interface lets you choose which punctuation characters trigger
 segmentation (comma, period, question mark and exclamation point) and specify a
-minimum and maximum token count for each segment.
+minimum and maximum token count for each segment. The limits are ignored when
+`full_segment` is selected.
 
 While generating audio, the CLI prints a segmentation log showing where each
 chunk starts and ends. After all segments are generated they are automatically


### PR DESCRIPTION
## Summary
- adjust `split_prompt_full` to ignore token counts
- update gradio inference to pass only characters when using `full_segment`
- document that token limits are ignored in `full_segment` mode

## Testing
- `python scripts/check_env.py` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68480070796c8327a548431c314c2f6d