### PR TITLE
Add Full Segment Test tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,14 +106,20 @@ token limit. Use `--segment` along with `--segment-by tokens` (default),
 chunked. Sentence segmentation usually produces smoother audio because pauses
 occur at natural boundaries. The `full_segment` mode splits on every comma,
 period, question mark or exclamation point, producing the smallest possible
-chunks. When splitting by sentences, commas are also considered separators. The
+chunks and ignoring the token count settings. When splitting by sentences,
+commas are also considered separators. The
 algorithm ignores consecutive commas and merges pieces shorter than three words
 with their neighbors so lists or short phrases aren't broken awkwardly. Enable
 sentence segmentation for long prompts with natural pause points.
 
 The Gradio interface lets you choose which punctuation characters trigger
 segmentation (comma, period, question mark and exclamation point) and specify a
-minimum and maximum token count for each segment.
+minimum and maximum token count for each segment. The limits are ignored when
+`full_segment` is selected.
+
+There is also a **Full Segment Test** tab in the web UI. This simplified
+interface exposes only character-based segmentation so you can verify how the
+`full_segment` mode splits prompts without any token settings.
 
 While generating audio, the CLI prints a segmentation log showing where each
 chunk starts and ends. After all segments are generated they are automatically

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -489,30 +489,15 @@ def split_prompt_full(
     text: str,
     tokenizer,
     chars: list[str] | None = None,
-    max_tokens: int = 50,
-    min_tokens: int = 0,
     return_text: bool = False,
 ) -> list[torch.Tensor] | tuple[list[str], list[torch.Tensor]]:
-    """Split ``text`` at selected punctuation marks."""
+    """Split ``text`` at selected punctuation marks ignoring token limits."""
     if not chars:
         chars = [",", ".", "?", "!"]
     char_class = "".join(re.escape(c) for c in chars)
     pattern = rf"[^{char_class}]+(?:[{char_class}]+|$)"
-    parts = [p.strip() for p in re.findall(pattern, text.strip()) if p.strip()]
-    segments: list[str] = []
-    current: list[str] = []
-    for part in parts:
-        candidate = " ".join(current + [part])
-        token_len = len(tokenizer(candidate, add_special_tokens=False).input_ids)
-        if token_len > max_tokens and current:
-            segments.append(" ".join(current))
-            current = [part]
-        else:
-            current.append(part)
-    if current:
-        segments.append(" ".join(current))
+    segments = [p.strip() for p in re.findall(pattern, text.strip()) if p.strip()]
     token_segments = [tokenizer(s, return_tensors="pt").input_ids.squeeze(0) for s in segments]
-    segments, token_segments = _merge_short_segments(segments, token_segments, min_tokens)
     return (segments, token_segments) if return_text else token_segments
 
 
@@ -664,8 +649,6 @@ def generate_audio(
                 text,
                 tokenizer,
                 chars=seg_chars,
-                max_tokens=seg_max_tokens,
-                min_tokens=seg_min_tokens,
                 return_text=True,
             )
         else:
@@ -1052,6 +1035,54 @@ with gr.Blocks() as demo:
         )
 
         clear_btn.click(lambda: ("", None), None, [gallery, last_audio], queue=False)
+
+    with gr.Tab("Full Segment Test"):
+        fs_prompt = gr.Textbox(label="Prompt")
+        fs_lora = gr.Dropdown(choices=["<base>"] + lora_choices, multiselect=True, label="LoRA(s)")
+        fs_chars = gr.CheckboxGroup([",", ".", "?", "!"], value=[",", ".", "?", "!"], label="Segment characters")
+        with gr.Accordion("Advanced Settings", open=False):
+            fs_temperature = gr.Slider(0.1, 1.5, value=0.6, label="Temperature")
+            fs_top_p = gr.Slider(0.5, 1.0, value=0.95, label="Top P")
+            fs_rep_penalty = gr.Slider(1.0, 2.0, value=1.1, label="Repetition Penalty")
+            fs_max_tokens = gr.Number(value=1200, precision=0, label="Max New Tokens")
+            fs_gap = gr.Number(value=0.0, precision=1, label="Gap between segments (s)")
+        fs_btn = gr.Button("Generate")
+        fs_clear = gr.Button("Clear Gallery")
+        fs_gallery = gr.HTML(label="Outputs")
+        fs_last_audio = gr.Audio(label="Last Audio")
+
+        def run_full_seg(prompt, loras, temp, top_p_val, rep, max_tok, seg_chars, gap):
+            return generate_batch(
+                [prompt] if prompt else [],
+                loras or [None],
+                temp,
+                top_p_val,
+                rep,
+                max_tok,
+                True,
+                "full_segment",
+                seg_chars or [],
+                0,
+                50,
+                gap,
+            )
+
+        fs_btn.click(
+            run_full_seg,
+            [
+                fs_prompt,
+                fs_lora,
+                fs_temperature,
+                fs_top_p,
+                fs_rep_penalty,
+                fs_max_tokens,
+                fs_chars,
+                fs_gap,
+            ],
+            [fs_gallery, fs_last_audio],
+        )
+
+        fs_clear.click(lambda: ("", None), None, [fs_gallery, fs_last_audio], queue=False)
 
     with gr.Tab("Auto Pipeline"):
         auto_dataset = gr.Dropdown(choices=list_source_audio(), label="Dataset")


### PR DESCRIPTION
## Summary
- add simplified `Full Segment Test` tab to Gradio interface
- document new tab in README

## Testing
- `python scripts/check_env.py` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68480070796c8327a548431c314c2f6d