### PR TITLE
Fix dependency installation for Python 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,6 @@ soundfile
 librosa
 evaluate
 jiwer
-wespeaker @ git+https://github.com/wenet-e2e/wespeaker.git
 cloudpickle
 openai
 py-cpuinfo

--- a/requirements_grpo.txt
+++ b/requirements_grpo.txt
@@ -12,7 +12,6 @@ librosa
 evaluate
 jiwer
 # git repo for wespeaker
-wespeaker @ git+https://github.com/wenet-e2e/wespeaker.git
 cloudpickle
 openai
 py-cpuinfo

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,10 +17,12 @@ fi
 source "$VENV_DIR/bin/activate"
 
 pip install --upgrade pip setuptools wheel
+pip install --upgrade cython
 pip install bitsandbytes accelerate xformers==0.0.29.post3 peft trl==0.15.2 triton cut_cross_entropy unsloth_zoo sentencepiece protobuf "datasets>=3.4.1" huggingface_hub hf_transfer transformers==4.51.3 unsloth snac torchaudio ipython librosa soundfile whisperx gradio
 
 # Install project requirements including GRPO extras
 pip install -r requirements.txt
+pip install --no-build-isolation git+https://github.com/wenet-e2e/wespeaker.git
 
 if command -v apt-get >/dev/null; then
   apt-get update && apt-get install -y ffmpeg


### PR DESCRIPTION
## Summary
- install cython before installing requirements
- handle wespeaker installation separately without build isolation
- remove wespeaker entry from `requirements.txt`

## Testing
- `python -m py_compile scripts/check_env.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68495d216b9c83279de106f6c76feb38