### PR TITLE
Integrate long form features into CLI scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ python scripts/orpheus_cli.py
 - Segmentation mode prints the start and end index of each chunk so you know where text was split
 - Trained LoRA adapters are stored under `lora_models/<dataset>/lora_model`
 - Detailed logs for the CLI and Gradio interface are saved under `logs/orpheus.log`
+- The **Long Form** tab chunks large prompts, processes them in parallel and assembles a single audio file. Batch size controls how many chunks run concurrently.
+- vLLM settings are applied automatically to allow context lengths up to 100k tokens while disabling telemetry.
 
 All features are available via an interactive command-line menu.
 

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -11,12 +11,21 @@ import os
 from pathlib import Path
 import json
 import re
+import asyncio
 import unsloth  # must be imported before transformers
 from transformers import AutoTokenizer
 import gradio as gr
 import gc
 import time
 from tools.logger_utils import get_logger
+
+# Configure vLLM environment for long contexts and reduced logging
+os.environ.setdefault("VLLM_MAX_MODEL_LEN", "100000")
+os.environ.setdefault("VLLM_GPU_MEMORY_UTILIZATION", "0.9")
+os.environ.setdefault("VLLM_DISABLE_LOGGING", "1")
+os.environ.setdefault("VLLM_NO_USAGE_STATS", "1")
+os.environ.setdefault("VLLM_DO_NOT_TRACK", "1")
+os.environ.setdefault("GRADIO_ANALYTICS_ENABLED", "0")
 
 # Helper for audio concatenation with crossfade
 from audio_utils import concat_with_fade
@@ -563,6 +572,9 @@ def generate_audio_segment(
     model,
     snac_model,
     max_new_tokens: int = 1200,
+    temperature: float = 0.6,
+    top_p: float = 0.95,
+    repetition_penalty: float = 1.1,
 ) -> torch.Tensor:
     logger.info("Generating segment with %d tokens", tokens.numel())
     t0 = time.perf_counter()
@@ -577,9 +589,9 @@ def generate_audio_segment(
         attention_mask=attn_cuda,
         max_new_tokens=max_new_tokens,
         do_sample=True,
-        temperature=0.6,
-        top_p=0.95,
-        repetition_penalty=1.1,
+        temperature=temperature,
+        top_p=top_p,
+        repetition_penalty=repetition_penalty,
         num_return_sequences=1,
         eos_token_id=128258,
         use_cache=True,
@@ -688,7 +700,13 @@ def generate_audio(
     final_audio = None
     for s in segments:
         part = generate_audio_segment(
-            s, model, snac_model, max_new_tokens=max_new_tokens
+            s,
+            model,
+            snac_model,
+            max_new_tokens=max_new_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            repetition_penalty=repetition_penalty,
         )
         if final_audio is None:
             final_audio = part
@@ -780,6 +798,98 @@ def dataset_status(name: str) -> str:
     ds_name = Path(name).stem
     lora_path = LORA_DIR / ds_name / "lora_model"
     return "Model already created" if lora_path.is_dir() else ""
+
+
+async def _generate_long_form_async(
+    segments: list[torch.Tensor],
+    model,
+    snac_model,
+    batch_size: int,
+    max_new_tokens: int,
+    temperature: float,
+    top_p: float,
+    repetition_penalty: float,
+    progress: gr.Progress | None = None,
+) -> list[torch.Tensor]:
+    """Generate audio segments concurrently respecting *batch_size*."""
+    semaphore = asyncio.Semaphore(batch_size)
+    results: list[torch.Tensor] = [None] * len(segments)  # type: ignore
+    loop = asyncio.get_event_loop()
+    completed = 0
+
+    async def process(idx: int, ids: torch.Tensor) -> None:
+        nonlocal completed
+        async with semaphore:
+            audio = await loop.run_in_executor(
+                None,
+                lambda: generate_audio_segment(
+                    ids,
+                    model,
+                    snac_model,
+                    max_new_tokens=max_new_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                    repetition_penalty=repetition_penalty,
+                ),
+            )
+            results[idx] = audio
+            completed += 1
+            if progress is not None:
+                progress(completed / len(segments), desc=f"Chunk {completed}/{len(segments)}")
+
+    tasks = [process(i, seg) for i, seg in enumerate(segments)]
+    await asyncio.gather(*tasks)
+    return results
+
+
+def generate_long_form(
+    text: str,
+    lora_name: str | None,
+    temperature: float,
+    top_p: float,
+    repetition_penalty: float,
+    max_new_tokens: int,
+    batch_size: int = 4,
+    fade_ms: int = 60,
+) -> str:
+    """Generate long form audio by chunking and processing in parallel."""
+    model_name = MODEL_NAME
+    lora_path = None
+    if lora_name:
+        lora_path = LORA_DIR / lora_name / "lora_model"
+    model, tokenizer = load_model(model_name, str(lora_path) if lora_path else None)
+    snac_model = get_snac_model()
+
+    segments = split_prompt_by_sentences(text, tokenizer, max_tokens=300)
+    progress = gr.Progress()
+    audio_parts = asyncio.run(
+        _generate_long_form_async(
+            segments,
+            model,
+            snac_model,
+            batch_size,
+            max_new_tokens,
+            temperature,
+            top_p,
+            repetition_penalty,
+            progress,
+        )
+    )
+    final_audio = None
+    for part in audio_parts:
+        if final_audio is None:
+            final_audio = part
+        else:
+            final_audio = concat_with_fade([final_audio, part], fade_ms=fade_ms)
+    if final_audio is None:
+        return ""
+    path = get_output_path(lora_name or "base_model")
+    import torchaudio
+    torchaudio.save(str(path), final_audio.detach().cpu(), 24000)
+    torch.cuda.empty_cache()
+    gc.collect()
+    logger.info("Saved long form audio to %s", path)
+    return str(path)
 
 
 def run_full_pipeline(dataset_file: str, prompt: str, fade_ms: int = 60) -> tuple[str, str]:
@@ -1024,6 +1134,42 @@ with gr.Blocks() as demo:
 
                     clear_btn.click(lambda: ("", None), None, [gallery, last_audio], queue=False)
 
+                with gr.Tab("Long Form"):
+                    lf_prompt = gr.Textbox(label="Text", lines=15)
+                    lf_lora = gr.Dropdown(choices=["<base>"] + lora_choices, label="LoRA")
+                    lf_batch = gr.Slider(1, 10, value=4, step=1, label="Batch Size")
+                    with gr.Accordion("Advanced Settings", open=False):
+                        lf_temp = gr.Slider(0.1, 1.5, value=0.6, label="Temperature")
+                        lf_top_p = gr.Slider(0.5, 1.0, value=0.95, label="Top P")
+                        lf_rep = gr.Slider(1.0, 2.0, value=1.1, label="Repetition Penalty")
+                        lf_max_tok = gr.Number(value=4096, precision=0, label="Max New Tokens")
+                        lf_fade = gr.Number(value=60, precision=0, label="Crossfade (ms)")
+                    lf_btn = gr.Button("Generate")
+                    lf_audio = gr.Audio(label="Output")
+
+                    lf_btn.click(
+                        lambda *args: generate_long_form(
+                            args[0],
+                            None if args[1] == "<base>" else args[1],
+                            args[3],
+                            args[4],
+                            args[5],
+                            int(args[6]),
+                            int(args[2]),
+                            int(args[7]),
+                        ),
+                        [
+                            lf_prompt,
+                            lf_lora,
+                            lf_batch,
+                            lf_temp,
+                            lf_top_p,
+                            lf_rep,
+                            lf_max_tok,
+                            lf_fade,
+                        ],
+                        lf_audio,
+                    )
 
 
         with gr.Tab("TESTING"):

--- a/scripts/infer.py
+++ b/scripts/infer.py
@@ -2,6 +2,7 @@
 import argparse
 import os
 import json
+import asyncio
 import torch
 import torchaudio
 import re
@@ -23,6 +24,13 @@ if repo_root not in sys.path:
     sys.path.insert(0, repo_root)
 
 from audio_utils import concat_with_fade
+
+# Configure vLLM environment for long contexts and no telemetry
+os.environ.setdefault("VLLM_MAX_MODEL_LEN", "100000")
+os.environ.setdefault("VLLM_GPU_MEMORY_UTILIZATION", "0.9")
+os.environ.setdefault("VLLM_DISABLE_LOGGING", "1")
+os.environ.setdefault("VLLM_NO_USAGE_STATS", "1")
+os.environ.setdefault("VLLM_DO_NOT_TRACK", "1")
 
 CACHE_DIR = os.path.join(os.path.dirname(__file__), '..', 'models')
 
@@ -70,6 +78,9 @@ def generate_audio_segment(
     model,
     snac_model,
     max_new_tokens: int = 1200,
+    temperature: float = 0.6,
+    top_p: float = 0.95,
+    repetition_penalty: float = 1.1,
 ) -> torch.Tensor:
     """Generate audio for given token IDs and return as 1D tensor."""
     start_token = torch.tensor([[128259]], dtype=torch.int64)
@@ -83,9 +94,9 @@ def generate_audio_segment(
         attention_mask=attn_cuda,
         max_new_tokens=max_new_tokens,
         do_sample=True,
-        temperature=0.6,
-        top_p=0.95,
-        repetition_penalty=1.1,
+        temperature=temperature,
+        top_p=top_p,
+        repetition_penalty=repetition_penalty,
         num_return_sequences=1,
         eos_token_id=128258,
         use_cache=True,
@@ -131,6 +142,73 @@ def generate_audio_segment(
     samples = [redistribute_codes(c) for c in code_lists]
     return samples[0].squeeze(0)
 
+
+async def _generate_long_form_async(
+    segments: list[torch.Tensor],
+    model,
+    snac_model,
+    batch_size: int,
+    max_new_tokens: int,
+    temperature: float,
+    top_p: float,
+    repetition_penalty: float,
+) -> list[torch.Tensor]:
+    """Generate audio segments concurrently respecting *batch_size*."""
+    semaphore = asyncio.Semaphore(batch_size)
+    results: list[torch.Tensor] = [None] * len(segments)  # type: ignore
+    loop = asyncio.get_event_loop()
+
+    async def process(i: int, ids: torch.Tensor) -> None:
+        async with semaphore:
+            audio = await loop.run_in_executor(
+                None,
+                lambda: generate_audio_segment(
+                    ids,
+                    model,
+                    snac_model,
+                    max_new_tokens=max_new_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                    repetition_penalty=repetition_penalty,
+                ),
+            )
+            results[i] = audio
+
+    await asyncio.gather(*(process(i, seg) for i, seg in enumerate(segments)))
+    return results
+
+
+def generate_long_form(
+    text: str,
+    model,
+    tokenizer,
+    snac_model,
+    temperature: float,
+    top_p: float,
+    repetition_penalty: float,
+    max_new_tokens: int,
+    batch_size: int,
+    fade_ms: int,
+) -> torch.Tensor | None:
+    """Generate long form audio by chunking and processing in parallel."""
+    segments = split_prompt_by_sentences(text, tokenizer, max_tokens=300)
+    audio_parts = asyncio.run(
+        _generate_long_form_async(
+            segments,
+            model,
+            snac_model,
+            batch_size,
+            max_new_tokens,
+            temperature,
+            top_p,
+            repetition_penalty,
+        )
+    )
+    final = None
+    for part in audio_parts:
+        final = part if final is None else concat_with_fade([final, part], fade_ms=fade_ms)
+    return final
+
 def main():
     parser = argparse.ArgumentParser(description='Interactive Orpheus TTS inference')
     parser.add_argument('--model', default='unsloth/orpheus-3b-0.1-ft', help='Model name or path')
@@ -153,6 +231,35 @@ def main():
         type=int,
         default=60,
         help='Crossfade duration in milliseconds',
+    )
+    parser.add_argument(
+        '--temperature',
+        type=float,
+        default=0.6,
+        help='Generation temperature',
+    )
+    parser.add_argument(
+        '--top_p',
+        type=float,
+        default=0.95,
+        help='Top-p sampling',
+    )
+    parser.add_argument(
+        '--repetition_penalty',
+        type=float,
+        default=1.1,
+        help='Repetition penalty',
+    )
+    parser.add_argument(
+        '--batch_size',
+        type=int,
+        default=4,
+        help='Concurrent chunk batch size for long form mode',
+    )
+    parser.add_argument(
+        '--long_form',
+        action='store_true',
+        help='Enable asynchronous long form generation',
     )
     args = parser.parse_args()
     model, tokenizer = load_model(args.model, args.lora)
@@ -214,26 +321,49 @@ def main():
             text = input('Enter text (or blank to quit): ').strip()
         if not text:
             break
-        if args.segment:
-            if args.segment_by == 'sentence':
-                seg_text, segments = split_prompt_by_sentences(text, tokenizer, return_text=True)
-            else:
-                seg_text, segments = split_prompt_by_tokens(text, tokenizer, return_text=True)
-            print_segment_log(text, seg_text)
-        else:
-            segments = [tokenizer(text, return_tensors='pt').input_ids.squeeze(0)]
-        start_time = time.perf_counter()
-        final_audio = None
-        for ids in segments:
-            part = generate_audio_segment(
-                ids, model, snac_model, max_new_tokens=args.max_tokens
+        if args.long_form:
+            start_time = time.perf_counter()
+            final_audio = generate_long_form(
+                text,
+                model,
+                tokenizer,
+                snac_model,
+                args.temperature,
+                args.top_p,
+                args.repetition_penalty,
+                args.max_tokens,
+                args.batch_size,
+                args.fade_ms,
             )
-            if final_audio is None:
-                final_audio = part
-            else:
-                final_audio = concat_with_fade([final_audio, part], fade_ms=args.fade_ms)
             torch.cuda.empty_cache()
             gc.collect()
+        else:
+            if args.segment:
+                if args.segment_by == 'sentence':
+                    seg_text, segments = split_prompt_by_sentences(text, tokenizer, return_text=True)
+                else:
+                    seg_text, segments = split_prompt_by_tokens(text, tokenizer, return_text=True)
+                print_segment_log(text, seg_text)
+            else:
+                segments = [tokenizer(text, return_tensors='pt').input_ids.squeeze(0)]
+            start_time = time.perf_counter()
+            final_audio = None
+            for ids in segments:
+                part = generate_audio_segment(
+                    ids,
+                    model,
+                    snac_model,
+                    max_new_tokens=args.max_tokens,
+                    temperature=args.temperature,
+                    top_p=args.top_p,
+                    repetition_penalty=args.repetition_penalty,
+                )
+                if final_audio is None:
+                    final_audio = part
+                else:
+                    final_audio = concat_with_fade([final_audio, part], fade_ms=args.fade_ms)
+                torch.cuda.empty_cache()
+                gc.collect()
         if final_audio is None:
             continue
         elapsed = time.perf_counter() - start_time

--- a/scripts/infer_interactive.py
+++ b/scripts/infer_interactive.py
@@ -14,6 +14,7 @@ import torchaudio
 import re
 import gc
 import time
+import asyncio
 from unsloth import FastLanguageModel
 from snac import SNAC
 from peft import PeftModel
@@ -25,6 +26,13 @@ if repo_root not in sys.path:
     sys.path.insert(0, repo_root)
 
 from audio_utils import concat_with_fade
+
+# Configure vLLM environment for long contexts and no telemetry
+os.environ.setdefault("VLLM_MAX_MODEL_LEN", "100000")
+os.environ.setdefault("VLLM_GPU_MEMORY_UTILIZATION", "0.9")
+os.environ.setdefault("VLLM_DISABLE_LOGGING", "1")
+os.environ.setdefault("VLLM_NO_USAGE_STATS", "1")
+os.environ.setdefault("VLLM_DO_NOT_TRACK", "1")
 
 CACHE_DIR = os.path.join(os.path.dirname(__file__), '..', 'models')
 
@@ -128,6 +136,9 @@ def generate_audio_segment(
     model,
     snac_model,
     max_new_tokens: int = 1200,
+    temperature: float = 0.6,
+    top_p: float = 0.95,
+    repetition_penalty: float = 1.1,
 ) -> torch.Tensor:
     """Generate audio for a single token chunk and return as 1D tensor."""
     start_token = torch.tensor([[128259]], dtype=torch.int64)
@@ -141,9 +152,9 @@ def generate_audio_segment(
         attention_mask=attn_cuda,
         max_new_tokens=max_new_tokens,
         do_sample=True,
-        temperature=0.6,
-        top_p=0.95,
-        repetition_penalty=1.1,
+        temperature=temperature,
+        top_p=top_p,
+        repetition_penalty=repetition_penalty,
         num_return_sequences=1,
         eos_token_id=128258,
         use_cache=True,
@@ -190,6 +201,73 @@ def generate_audio_segment(
     return samples[0].squeeze(0)
 
 
+async def _generate_long_form_async(
+    segments: list[torch.Tensor],
+    model,
+    snac_model,
+    batch_size: int,
+    max_new_tokens: int,
+    temperature: float,
+    top_p: float,
+    repetition_penalty: float,
+) -> list[torch.Tensor]:
+    """Generate audio segments concurrently respecting *batch_size*."""
+    semaphore = asyncio.Semaphore(batch_size)
+    results: list[torch.Tensor] = [None] * len(segments)  # type: ignore
+    loop = asyncio.get_event_loop()
+
+    async def process(i: int, ids: torch.Tensor) -> None:
+        async with semaphore:
+            audio = await loop.run_in_executor(
+                None,
+                lambda: generate_audio_segment(
+                    ids,
+                    model,
+                    snac_model,
+                    max_new_tokens=max_new_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                    repetition_penalty=repetition_penalty,
+                ),
+            )
+            results[i] = audio
+
+    await asyncio.gather(*(process(i, seg) for i, seg in enumerate(segments)))
+    return results
+
+
+def generate_long_form(
+    text: str,
+    model,
+    tokenizer,
+    snac_model,
+    temperature: float,
+    top_p: float,
+    repetition_penalty: float,
+    max_new_tokens: int,
+    batch_size: int,
+    fade_ms: int,
+) -> torch.Tensor | None:
+    """Generate long form audio by chunking and processing in parallel."""
+    segments = split_prompt_by_sentences(text, tokenizer, max_tokens=300)
+    audio_parts = asyncio.run(
+        _generate_long_form_async(
+            segments,
+            model,
+            snac_model,
+            batch_size,
+            max_new_tokens,
+            temperature,
+            top_p,
+            repetition_penalty,
+        )
+    )
+    final = None
+    for part in audio_parts:
+        final = part if final is None else concat_with_fade([final, part], fade_ms=fade_ms)
+    return final
+
+
 def main():
     parser = argparse.ArgumentParser(description="Interactive inference")
     parser.add_argument(
@@ -214,6 +292,35 @@ def main():
         type=int,
         default=60,
         help="Crossfade duration in milliseconds",
+    )
+    parser.add_argument(
+        "--temperature",
+        type=float,
+        default=0.6,
+        help="Generation temperature",
+    )
+    parser.add_argument(
+        "--top_p",
+        type=float,
+        default=0.95,
+        help="Top-p sampling",
+    )
+    parser.add_argument(
+        "--repetition_penalty",
+        type=float,
+        default=1.1,
+        help="Repetition penalty",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=4,
+        help="Concurrent chunk batch size for long form mode",
+    )
+    parser.add_argument(
+        "--long_form",
+        action="store_true",
+        help="Enable asynchronous long form generation",
     )
     args = parser.parse_args()
 
@@ -309,26 +416,49 @@ def main():
         model, tokenizer = load_model(model_name, lora_path)
 
         for text in prompts:
-            if segment_choice:
-                if args.segment_by == "sentence":
-                    seg_text, segments = split_prompt_by_sentences(text, tokenizer, return_text=True)
-                else:
-                    seg_text, segments = split_prompt_by_tokens(text, tokenizer, return_text=True)
-                print_segment_log(text, seg_text)
-            else:
-                segments = [tokenizer(text, return_tensors="pt").input_ids.squeeze(0)]
-            start_time = time.perf_counter()
-            final_audio = None
-            for ids in segments:
-                part = generate_audio_segment(
-                    ids, model, snac_model, max_new_tokens=args.max_tokens
+            if args.long_form:
+                start_time = time.perf_counter()
+                final_audio = generate_long_form(
+                    text,
+                    model,
+                    tokenizer,
+                    snac_model,
+                    args.temperature,
+                    args.top_p,
+                    args.repetition_penalty,
+                    args.max_tokens,
+                    args.batch_size,
+                    args.fade_ms,
                 )
-                if final_audio is None:
-                    final_audio = part
-                else:
-                    final_audio = concat_with_fade([final_audio, part], fade_ms=args.fade_ms)
                 torch.cuda.empty_cache()
                 gc.collect()
+            else:
+                if segment_choice:
+                    if args.segment_by == "sentence":
+                        seg_text, segments = split_prompt_by_sentences(text, tokenizer, return_text=True)
+                    else:
+                        seg_text, segments = split_prompt_by_tokens(text, tokenizer, return_text=True)
+                    print_segment_log(text, seg_text)
+                else:
+                    segments = [tokenizer(text, return_tensors="pt").input_ids.squeeze(0)]
+                start_time = time.perf_counter()
+                final_audio = None
+                for ids in segments:
+                    part = generate_audio_segment(
+                        ids,
+                        model,
+                        snac_model,
+                        max_new_tokens=args.max_tokens,
+                        temperature=args.temperature,
+                        top_p=args.top_p,
+                        repetition_penalty=args.repetition_penalty,
+                    )
+                    if final_audio is None:
+                        final_audio = part
+                    else:
+                        final_audio = concat_with_fade([final_audio, part], fade_ms=args.fade_ms)
+                    torch.cuda.empty_cache()
+                    gc.collect()
             if final_audio is None:
                 continue
             elapsed = time.perf_counter() - start_time

--- a/scripts/orpheus_cli.py
+++ b/scripts/orpheus_cli.py
@@ -57,9 +57,12 @@ def train():
 def infer():
     multi = input("Run inference on multiple models? (y/N): ").strip().lower() == "y"
     segment = input("Segment prompts every 50 tokens? (y/N): ").strip().lower() == "y"
+    long_form = input("Use long form mode? (y/N): ").strip().lower() == "y"
     cmd = ["python", "infer_interactive.py"]
     if segment:
         cmd.append("--segment")
+    if long_form:
+        cmd.append("--long_form")
     while True:
         run_script(cmd)
         if not multi:


### PR DESCRIPTION
## Summary
- apply vLLM environment settings to inference scripts
- add async long-form generation utilities
- expose temperature, top_p, rep_penalty and batching options
- support `--long_form` mode in `infer.py` and `infer_interactive.py`
- allow CLI menu to trigger long form mode

## Testing
- `python -m py_compile gradio_app.py audio_utils.py scripts/orpheus_cli.py`
- `python -m py_compile scripts/infer.py scripts/infer_interactive.py`


------
https://chatgpt.com/codex/tasks/task_e_6849bdbeffa48327b14600dc6c118432