### PR TITLE
Add wrapper for vLLM config

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To start:
 If you prefer a simple web UI instead of the CLI, run:
 
 ```bash
-python gradio_app.py
+python orpheus_wrapper.py
 ```
 
 

--- a/orpheus_wrapper.py
+++ b/orpheus_wrapper.py
@@ -1,0 +1,47 @@
+import os
+
+# Set environment variables for vLLM and Gradio behaviour
+DEFAULTS = {
+    "VLLM_MAX_MODEL_LEN": "4096",
+    "VLLM_GPU_MEMORY_UTILIZATION": "0.90",
+    "VLLM_DISABLE_LOGGING": "1",
+    "VLLM_NO_USAGE_STATS": "1",
+    "VLLM_DO_NOT_TRACK": "1",
+    "GRADIO_ANALYTICS_ENABLED": "False",
+}
+for key, val in DEFAULTS.items():
+    os.environ.setdefault(key, val)
+
+from vllm.engine.async_llm_engine import AsyncLLMEngine, AsyncEngineArgs
+
+# Patch AsyncLLMEngine.from_engine_args to apply environment defaults
+_orig_from_engine_args = AsyncLLMEngine.from_engine_args.__func__  # type: ignore
+
+def _patched_from_engine_args(cls, engine_args: AsyncEngineArgs, *args, **kwargs):
+    max_len = os.getenv("VLLM_MAX_MODEL_LEN")
+    if max_len:
+        try:
+            engine_args.max_model_len = int(max_len)
+        except ValueError:
+            pass
+    gpu_util = os.getenv("VLLM_GPU_MEMORY_UTILIZATION")
+    if gpu_util:
+        try:
+            engine_args.gpu_memory_utilization = float(gpu_util)
+        except ValueError:
+            pass
+    return _orig_from_engine_args(cls, engine_args, *args, **kwargs)
+
+AsyncLLMEngine.from_engine_args = classmethod(_patched_from_engine_args)
+
+# Import the existing Gradio app and launch it
+import gradio_app
+
+
+def main() -> None:
+    """Launch the Gradio app with patched vLLM settings."""
+    gradio_app.demo.launch(server_port=18188)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- provide `orpheus_wrapper.py` to set vLLM defaults and launch the Gradio app
- document the new startup command in README

## Testing
- `python -m py_compile orpheus_wrapper.py gradio_app.py`


------
https://chatgpt.com/codex/tasks/task_e_684adee82da08327885c2d581b0ff97f