### PR TITLE
Fix progress bar not appearing in Gradio UI

### DIFF
--- a/orpheusx/app.py
+++ b/orpheusx/app.py
@@ -3,6 +3,7 @@ from orpheusx.ui.gradio_ui import build_ui
 
 def main():
     demo = build_ui()
+    demo.queue()
     demo.launch(server_port=18188)
 
 


### PR DESCRIPTION
## Summary
- enable Gradio queue in `main()` so progress updates show

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bd2dce9748327b2ad0b43432f4540