### PR TITLE
Remove progress UI elements

### DIFF
--- a/orpheusx/app.py
+++ b/orpheusx/app.py
@@ -3,6 +3,7 @@ from orpheusx.ui.gradio_ui import build_ui
 
 def main():
     demo = build_ui()
+    demo.queue()
     demo.launch(server_port=18188)
 
 

--- a/orpheusx/pipeline/data.py
+++ b/orpheusx/pipeline/data.py
@@ -98,13 +98,11 @@ def prepare_datasets_ui(
     msgs: list[str] = []
     logger.info("Preparing %d dataset(s)", len(tasks))
     total = len(tasks)
-    progress = gr.Progress()
     for idx, (audio_path, ds_name) in enumerate(tasks, start=1):
         if _c.STOP_FLAG:
             _c.STOP_FLAG = False
             return "Stopped"
         start = time.perf_counter()
-        progress((idx - 1) / total, desc=f"Preparing {ds_name}...")
         out_dir = DATASETS_DIR / ds_name
         out_dir.parent.mkdir(parents=True, exist_ok=True)
         try:
@@ -121,7 +119,7 @@ def prepare_datasets_ui(
             elapsed = time.perf_counter() - start
             logger.exception("Error preparing %s after %.2fs", ds_name, elapsed)
             msgs.append(f"{ds_name}: failed ({e})")
-        progress(idx / total)
+
     return "\n".join(msgs)
 
 # -----------------------------------------------------------------------------

--- a/orpheusx/pipeline/infer.py
+++ b/orpheusx/pipeline/infer.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import List, Tuple
 
 import torch
-import gradio as gr
 from transformers import AutoTokenizer
 from peft import PeftModel
 from unsloth import FastLanguageModel
@@ -338,13 +337,11 @@ def generate_batch(
     last_path = ""
     total = len(prompts) * len(loras)
     step = 0
-    progress = gr.Progress()
     for lora in loras:
         for text in prompts:
             if _c.STOP_FLAG:
                 _c.STOP_FLAG = False
                 return "", ""
-            progress(step / total, desc=f"Generating {lora or 'base'}...")
             logger.info("Generating prompt '%s' with lora '%s'", text, lora or 'base_model')
             path = generate_audio(
                 text,
@@ -367,8 +364,6 @@ def generate_batch(
             results.append((path, caption))
             last_path = path
             step += 1
-    progress(1)
-
     html_items = [
         f"<div style='margin-bottom:1em'><p>{caption}</p><audio controls src='file={path}'></audio></div>"
         for path, caption in results

--- a/orpheusx/pipeline/train.py
+++ b/orpheusx/pipeline/train.py
@@ -4,7 +4,6 @@ import time
 import os
 from pathlib import Path
 
-import gradio as gr
 import torch
 from datasets import load_dataset, load_from_disk
 from transformers import TrainingArguments, Trainer
@@ -262,12 +261,10 @@ def train_loras(
     msgs: list[str] = []
     total = len(dataset_info)
     logger.info("Training %d LoRA(s)", total)
-    progress = gr.Progress()
     for idx, (src, name, is_local) in enumerate(dataset_info, start=1):
         if _c.STOP_FLAG:
             _c.STOP_FLAG = False
             return "Stopped"
-        progress((idx - 1) / total, desc=f"Training {name}...")
         start = time.perf_counter()
         try:
             _ = train_lora_single(
@@ -292,7 +289,6 @@ def train_loras(
             elapsed = time.perf_counter() - start
             logger.exception("Training failed for %s after %.2fs", name, elapsed)
             msgs.append(f"{name}: failed ({exc})")
-    progress(1)
     return "\n".join(msgs)
 
 __all__ = [

--- a/orpheusx/ui/gradio_ui.py
+++ b/orpheusx/ui/gradio_ui.py
@@ -54,14 +54,12 @@ def build_ui() -> gr.Blocks:
                             choices=prompt_files, label="Prompt List"
                         )
                         auto_btn = gr.Button("Run Pipeline")
-                        auto_log = gr.Textbox()
-                        auto_output = gr.HTML()
 
                         auto_dataset.change(dataset_status_multi, auto_dataset, auto_status)
                         auto_btn.click(
                             run_full_pipeline_batch,
                             [auto_dataset, auto_prompt, auto_prompt_file, auto_batch],
-                            [auto_log, auto_output],
+                            None,
                         )
 
         # Header buttons


### PR DESCRIPTION
## Summary
- remove progress calls from pipeline modules
- drop log textbox and HTML output from Gradio UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684bd2dce9748327b2ad0b43432f4540