### PR TITLE
Fix gradio audio playback

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -730,7 +730,13 @@ def generate_audio(
     lora_name = lora_name or "base_model"
     path = get_output_path(lora_name)
     import torchaudio
-    torchaudio.save(str(path), final_audio.detach().cpu(), 24000)
+    torchaudio.save(
+        str(path),
+        final_audio.detach().cpu(),
+        24000,
+        encoding="PCM_S",
+        bits_per_sample=16,
+    )
     torch.cuda.empty_cache()
     gc.collect()
     logger.info("Saved audio to %s", path)

--- a/scripts/infer.py
+++ b/scripts/infer.py
@@ -244,7 +244,13 @@ def main():
             rate = 0.0
         print(f"Inference time: {elapsed:.2f}s ({rate:.2f}s per generated second)")
         path = 'output.wav'
-        torchaudio.save(path, final_audio.detach().cpu(), 24000)
+        torchaudio.save(
+            path,
+            final_audio.detach().cpu(),
+            24000,
+            encoding="PCM_S",
+            bits_per_sample=16,
+        )
         print(f'Audio written to {path}')
         torch.cuda.empty_cache()
         gc.collect()

--- a/scripts/infer_interactive.py
+++ b/scripts/infer_interactive.py
@@ -338,7 +338,13 @@ def main():
                 f"Inference time: {elapsed:.2f}s ({rate:.2f}s per generated second)"
             )
             path = get_output_path(lora_choice or "base_model")
-            torchaudio.save(path, final_audio.detach().cpu(), 24000)
+            torchaudio.save(
+                path,
+                final_audio.detach().cpu(),
+                24000,
+                encoding="PCM_S",
+                bits_per_sample=16,
+            )
             print(f"Audio written to {path}")
             torch.cuda.empty_cache()
             gc.collect()


### PR DESCRIPTION
## Summary
- save generated audio as 16-bit PCM so browsers can decode it

## Testing
- `python -m py_compile gradio_app.py scripts/infer.py scripts/infer_interactive.py`

------
https://chatgpt.com/codex/tasks/task_e_684c03a824a88327ab49d10c77bea678