### PR TITLE
Enable queueing for stop button

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -1016,4 +1016,5 @@ with gr.Blocks() as demo:
     stop_btn.click(stop_current, None, None)
     exit_btn.click(exit_app, None, None)
 if __name__ == "__main__":
+    demo.queue(default_concurrency_limit=2)
     demo.launch(server_port=18188)


### PR DESCRIPTION
## Summary
- queue Gradio Blocks to allow concurrent requests
- fix parameter for `queue` call

## Testing
- `python -m py_compile gradio_app.py`


------
https://chatgpt.com/codex/tasks/task_e_684c273d207483278ba1104f8f1d90a4