### PR TITLE
Add advanced inference settings to Gradio

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -906,6 +906,16 @@ def run_full_pipeline_batch(
     prompt: str,
     prompt_file: str | None,
     batch: int,
+    temperature: float = 0.6,
+    top_p: float = 0.95,
+    repetition_penalty: float = 1.1,
+    max_new_tokens: int = 1200,
+    segment: bool = False,
+    segment_by: str = "tokens",
+    seg_chars: list[str] | None = None,
+    seg_min_tokens: int = 0,
+    seg_max_tokens: int = 50,
+    seg_gap: float = 0.0,
     fade_ms: int = 60,
 ) -> typing.Generator[tuple[str, str, str], None, None]:
     """Run the full pipeline for multiple datasets and prompts with live counter."""
@@ -924,11 +934,10 @@ def run_full_pipeline_batch(
             return
         prompts = [prompt] * max(1, int(batch or 1))
 
-    tokenizer = get_pipeline_tokenizer()
-    seg_needed = any(
-        len(tokenizer(p, add_special_tokens=False).input_ids) > 50 for p in prompts
-    )
-    max_tokens = 2400 if seg_needed else 1200
+    if isinstance(seg_chars, str):
+        seg_chars = [c.strip() for c in seg_chars.split() if c.strip()]
+
+    max_tokens = max_new_tokens
 
     msgs: list[str] = []
     html_blocks: dict[str, list[str]] = {
@@ -997,33 +1006,21 @@ def run_full_pipeline_batch(
 
         for text in prompts:
             progress(step / total_steps, desc=f"Generating {ds_name}")
-            if seg_needed:
-                path = generate_audio(
-                    text,
-                    ds_name,
-                    temperature=0.6,
-                    top_p=0.95,
-                    repetition_penalty=1.1,
-                    max_new_tokens=max_tokens,
-                    segment=True,
-                    segment_by="sentence",
-                    seg_chars=[",", ".", "?", "!"],
-                    seg_min_tokens=0,
-                    seg_max_tokens=50,
-                    seg_gap=0.0,
-                    fade_ms=fade_ms,
-                )
-            else:
-                path = generate_audio(
-                    text,
-                    ds_name,
-                    temperature=0.6,
-                    top_p=0.95,
-                    repetition_penalty=1.1,
-                    max_new_tokens=max_tokens,
-                    segment=False,
-                    fade_ms=fade_ms,
-                )
+            path = generate_audio(
+                text,
+                ds_name,
+                temperature=temperature,
+                top_p=top_p,
+                repetition_penalty=repetition_penalty,
+                max_new_tokens=max_tokens,
+                segment=segment,
+                segment_by=segment_by,
+                seg_chars=seg_chars,
+                seg_min_tokens=seg_min_tokens,
+                seg_max_tokens=seg_max_tokens,
+                seg_gap=seg_gap,
+                fade_ms=fade_ms,
+            )
             try:
                 with open(path, "rb") as f:
                     b64 = base64.b64encode(f.read()).decode("ascii")
@@ -1086,6 +1083,18 @@ with gr.Blocks(css=CSS) as demo:
             auto_prompt = gr.Textbox(label="Prompt")
             auto_batch = gr.Slider(1, 5, step=1, value=1, label="Batch")
             auto_prompt_file = gr.Dropdown(choices=[""] + prompt_files, label="Prompt List")
+            with gr.Accordion("Ajustes avanzados", open=False):
+                adv_temperature = gr.Slider(0.1, 1.0, value=0.6, step=0.05, label="Temperatura")
+                adv_top_p = gr.Slider(0.5, 1.0, value=0.95, step=0.05, label="Top-p")
+                adv_repeat = gr.Slider(1.0, 2.0, value=1.1, step=0.05, label="Repetición")
+                adv_max_tokens = gr.Slider(100, 3000, value=1200, step=10, label="Máx. nuevos tokens")
+                adv_segment = gr.Checkbox(False, label="Segmentar")
+                adv_segment_by = gr.Dropdown(["tokens", "sentence", "full_segment"], value="tokens", label="Segmentar por")
+                adv_seg_chars = gr.Textbox(value=", . ? !", label="Separadores")
+                adv_seg_min = gr.Slider(0, 50, value=0, step=1, label="Mín. tokens segmento")
+                adv_seg_max = gr.Slider(10, 100, value=50, step=1, label="Máx. tokens segmento")
+                adv_seg_gap = gr.Slider(0.0, 2.0, value=0.0, step=0.1, label="Pausa entre segmentos (s)")
+                adv_fade_ms = gr.Slider(0, 1000, value=60, step=10, label="Crossfade (ms)")
             auto_btn = gr.Button("Run Pipeline")
             with gr.Row():
                 auto_log = gr.Textbox(scale=1)
@@ -1094,7 +1103,23 @@ with gr.Blocks(css=CSS) as demo:
 
             auto_btn.click(
                 run_full_pipeline_batch,
-                [auto_dataset, auto_prompt, auto_prompt_file, auto_batch],
+                [
+                    auto_dataset,
+                    auto_prompt,
+                    auto_prompt_file,
+                    auto_batch,
+                    adv_temperature,
+                    adv_top_p,
+                    adv_repeat,
+                    adv_max_tokens,
+                    adv_segment,
+                    adv_segment_by,
+                    adv_seg_chars,
+                    adv_seg_min,
+                    adv_seg_max,
+                    adv_seg_gap,
+                    adv_fade_ms,
+                ],
                 [auto_log, auto_counter, auto_output],
             )
 


### PR DESCRIPTION
## Summary
- enable custom inference parameters in Gradio
- expose settings like temperature, top-p, segmentation and more under a new "Ajustes avanzados" accordion

## Testing
- `python -m py_compile gradio_app.py`

------
https://chatgpt.com/codex/tasks/task_e_684c3bb318f48327898626f6f09fb512